### PR TITLE
fix(cli): correct --title flag and AGENT_BLURB issue types

### DIFF
--- a/src/cli/commands/agents.rs
+++ b/src/cli/commands/agents.rs
@@ -12,10 +12,10 @@ use std::path::{Path, PathBuf};
 
 /// Current version of the agent instructions blurb.
 /// Increment this when making breaking changes to the blurb format.
-pub const BLURB_VERSION: u8 = 1;
+pub const BLURB_VERSION: u8 = 2;
 
 /// Start marker for the blurb (includes version).
-pub const BLURB_START_MARKER: &str = "<!-- br-agent-instructions-v1 -->";
+pub const BLURB_START_MARKER: &str = "<!-- br-agent-instructions-v2 -->";
 
 /// End marker for the blurb.
 pub const BLURB_END_MARKER: &str = "<!-- end-br-agent-instructions -->";
@@ -24,7 +24,7 @@ pub const BLURB_END_MARKER: &str = "<!-- end-br-agent-instructions -->";
 pub const SUPPORTED_AGENT_FILES: &[&str] = &["AGENTS.md", "CLAUDE.md", "agents.md", "claude.md"];
 
 /// The agent instructions blurb to append to AGENTS.md files.
-pub const AGENT_BLURB: &str = r#"<!-- br-agent-instructions-v1 -->
+pub const AGENT_BLURB: &str = r#"<!-- br-agent-instructions-v2 -->
 
 ---
 
@@ -66,7 +66,7 @@ br sync --status      # Check sync status
 
 - **Dependencies**: Issues can block other issues. `br ready` shows only unblocked work.
 - **Priority**: P0=critical, P1=high, P2=medium, P3=low, P4=backlog (use numbers 0-4, not words)
-- **Types**: task, bug, feature, epic, question, docs
+- **Types**: task, bug, feature, epic, chore
 - **Blocking**: `br dep add <issue> <depends-on>` to add dependencies
 
 ### Session Protocol
@@ -726,7 +726,7 @@ mod tests {
         let detection = detect_agent_file(temp_dir.path());
         assert!(detection.found());
         assert!(detection.has_blurb);
-        assert_eq!(detection.blurb_version, 1);
+        assert_eq!(detection.blurb_version, 2);
         assert!(!detection.needs_blurb());
         assert!(!detection.needs_upgrade());
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -283,7 +283,7 @@ pub struct CreateArgs {
     pub title: Option<String>,
 
     /// Issue title (alternative flag)
-    #[arg(long)]
+    #[arg(long = "title")]
     pub title_flag: Option<String>, // Handled in logic
 
     /// Issue type (task, bug, feature, etc.)

--- a/tests/snapshots/snapshots/snapshots__snapshots__cli_output__create_help.snap
+++ b/tests/snapshots/snapshots/snapshots__snapshots__cli_output__create_help.snap
@@ -10,7 +10,7 @@ Arguments:
   [TITLE]  Issue title
 
 Options:
-      --ID-REDACTED <TITLE_FLAG>      Issue title (alternative flag)
+      --title <TITLE_FLAG>           Issue title (alternative flag)
   -t, --type <TYPE>                  Issue type (task, bug, feature, etc.)
   -p, --priority <PRIORITY>          Priority (0-4 or P0-P4)
   -d, --description <DESCRIPTION>    Description


### PR DESCRIPTION
## Summary

- Fix `--title-flag` to be `--title` on the create command by explicitly setting the long flag name
- Correct AGENT_BLURB issue types from invalid `question, docs` to valid `chore`
- Bump AGENT_BLURB to version 2

## Test plan

- [x] `cargo build` succeeds
- [x] `br create --title="Test" --type=task --priority=2 --dry-run` works correctly
- [x] Snapshot tests updated and passing

## Merge order

⚠️ **Merge this PR before #10.** PR #10 depends on this PR being merged first (it bumps the blurb version to v3, expecting v2 from this PR to be in main).