### PR TITLE
fix(install): resolve silent failures when gum spinner is available

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -920,9 +920,10 @@ build_from_source() {
     local target_dir="$TMP/target"
     if [[ "$GUM_AVAILABLE" == "true" && "$QUIET" -eq 0 ]]; then
         gum spin --spinner dot --title "Compiling br (release mode)..." -- \
-            bash -c "cd '$build_dir' && CARGO_TARGET_DIR='$target_dir' cargo build --release 2>&1"
+            bash -c "cd '$build_dir' && CARGO_TARGET_DIR='$target_dir' cargo build --release" \
+            || die "Build failed"
     else
-        (cd "$build_dir" && CARGO_TARGET_DIR="$target_dir" cargo build --release 2>&1) || die "Build failed"
+        (cd "$build_dir" && CARGO_TARGET_DIR="$target_dir" cargo build --release) || die "Build failed"
     fi
 
     # Find the binary
@@ -949,8 +950,10 @@ download_release() {
     local archive_name="br-${VERSION}-${platform}.tar.gz"
     local url="https://github.com/${OWNER}/${REPO}/releases/download/${VERSION}/${archive_name}"
 
-    run_with_spinner "Downloading $archive_name..." \
-        download_file "$url" "$TMP/$archive_name"
+    log_step "Downloading $archive_name..."
+    if ! download_file "$url" "$TMP/$archive_name"; then
+        return 1
+    fi
 
     if [ ! -f "$TMP/$archive_name" ]; then
         return 1


### PR DESCRIPTION
## Summary
- Fix download_file call in `download_release()`
- Fix missing error handling for cargo build under gum
- Remove stderr redirects that hide error output

## Problem
The install script fails silently on systems with gum installed due to two issues:

1. `gum spin` cannot execute shell functions (only external binaries). When `run_with_spinner` calls `download_file`, gum fails with `exec: "download_file": executable file not found in $PATH`

2. The cargo build branch using gum was missing `|| die "Build failed"` that the else branch had, causing silent termination via `set -e`

3. The `2>&1` redirects hid all error output
