### PR TITLE
fix: change file permissions from 0o600 to 0o644 for multi-user access

### DIFF
--- a/PROPOSED_ARCHITECTURE_FOR_BR_USING_RUST_BEST_PRACTICES.md
+++ b/PROPOSED_ARCHITECTURE_FOR_BR_USING_RUST_BEST_PRACTICES.md
@@ -2590,11 +2590,11 @@ fn write_jsonl_atomic(issues: &[Issue], temp_path: &Path, final_path: &Path) -> 
     fs::rename(temp_path, final_path)
         .context("Failed to rename export file")?;
 
-    // Set permissions (0600)
+    // Set permissions (0644) - world-readable for multi-user/agent access
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
+        let perms = std::fs::Permissions::from_mode(0o644);
         fs::set_permissions(final_path, perms)?;
     }
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1387,11 +1387,11 @@ pub fn export_to_jsonl_with_policy(
     // Atomic rename
     fs::rename(&temp_path, output_path)?;
 
-    // Set file permissions (0600)
+    // Set file permissions (0644) - world-readable for multi-user/agent access
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
+        let perms = std::fs::Permissions::from_mode(0o644);
         let _ = fs::set_permissions(output_path, perms);
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -44,7 +44,7 @@ pub fn set_last_touched_id(beads_dir: &Path, id: &str) {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
+        options.mode(0o644);
     }
 
     if let Ok(mut file) = options.open(path) {
@@ -106,6 +106,6 @@ mod tests {
 
         set_last_touched_id(&beads_dir, "bd-abc123");
         let metadata = fs::metadata(last_touched_path(&beads_dir)).expect("metadata");
-        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o644);
     }
 }


### PR DESCRIPTION
## Summary

Hey Jeffrey! 👋

First off, a huge thank you from Larus (the human behind this PR) for sharing beads_rust with the community. We've been using it heavily in our multi-agent workflows and it's been fantastic.

This tiny PR is a small token of gratitude. Feel free to have your own AI agent submit it instead if you prefer - we don't care about attribution, just want to contribute back.

## The Change

Changes default file permissions from `0o600` (owner-only) to `0o644` (world-readable) for:
- `issues.jsonl` (main export file)
- `last-touched` (state file)

## Why

In multi-user/agent environments, `0o600` blocks non-owner read access. For example, user `clawd` couldn't read beads files owned by `larus`, breaking our agent coordination.

## Security Note

- `issues.jsonl` contains issue metadata, not secrets
- The data is typically committed to git anyway (already public)
- `0o644` is read-only for others - write protection maintained

## Files Changed

| File | Change |
|------|--------|
| `src/sync/mod.rs` | `0o600` → `0o644` for issues.jsonl |
| `src/util/mod.rs` | `0o600` → `0o644` for last-touched + test |
| `PROPOSED_ARCHITECTURE...md` | Updated docs to match |

## Testing

- `cargo check` passes
- Test assertion updated to expect `0o644`

Thanks again for the great tool! 🙏

— Larus & his clankers