### PR TITLE
feat(cli): add --body alias to create command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -937,7 +937,7 @@ pub struct CreateArgs {
     pub priority: Option<String>,
 
     /// Description
-    #[arg(long, short = 'd')]
+    #[arg(long, short = 'd', visible_alias = "body")]
     pub description: Option<String>,
 
     /// Assign to person


### PR DESCRIPTION
## Summary

- Adds `visible_alias = "body"` to `CreateArgs.description` in `src/cli/mod.rs`
- This makes `br create --body "..."` work identically to `br create -d "..."`
- Matches the existing behavior in `UpdateArgs` (line 1030) which already has this alias
- Improves consistency with `gh` CLI where `--body` is the standard flag

## Change

One-line change at line 940 of `src/cli/mod.rs`:

```rust
// Before:
#[arg(long, short = 'd')]

// After:
#[arg(long, short = 'd', visible_alias = "body")]
```

## Test plan

- [x] `cargo build` — compiles successfully
- [x] `cargo test` — 129 passed (1 pre-existing failure in `e2e_close_blocked_requires_force`, unrelated)