### PR TITLE
perf: fix 3 O(N^2) bottlenecks in import and blocked cache

### DIFF
--- a/src/cli/commands/blocked.rs
+++ b/src/cli/commands/blocked.rs
@@ -31,18 +31,18 @@ pub fn execute(
     tracing::info!("Fetching blocked issues from cache");
 
     let beads_dir = discover_beads_dir(None)?;
-    let storage_ctx = open_storage_with_cli(&beads_dir, overrides)?;
-    let storage = &storage_ctx.storage;
+    let mut storage_ctx = open_storage_with_cli(&beads_dir, overrides)?;
 
-    let config_layer = load_config(&beads_dir, Some(storage), overrides)?;
+    let config_layer = load_config(&beads_dir, Some(&storage_ctx.storage), overrides)?;
     let external_db_paths = external_project_db_paths(&config_layer, &beads_dir);
     let use_color = should_use_color(&config_layer);
     let output_format = resolve_output_format_basic(args.format, outer_ctx.is_json(), args.robot);
     let quiet = overrides.quiet.unwrap_or(false);
     let ctx = OutputContext::from_output_format(output_format, quiet, !use_color);
 
-    // Get blocked issues from cache
-    let blocked_raw = storage.get_blocked_issues()?;
+    // Get blocked issues from cache (needs &mut for lazy cache rebuild)
+    let blocked_raw = storage_ctx.storage.get_blocked_issues()?;
+    let storage = &storage_ctx.storage;
 
     tracing::debug!(
         count = blocked_raw.len(),

--- a/src/cli/commands/ready.rs
+++ b/src/cli/commands/ready.rs
@@ -27,10 +27,9 @@ pub fn execute(
 ) -> Result<()> {
     // Open storage
     let beads_dir = config::discover_beads_dir_with_cli(cli)?;
-    let storage_ctx = config::open_storage_with_cli(&beads_dir, cli)?;
-    let storage = &storage_ctx.storage;
+    let mut storage_ctx = config::open_storage_with_cli(&beads_dir, cli)?;
 
-    let config_layer = config::load_config(&beads_dir, Some(storage), cli)?;
+    let config_layer = config::load_config(&beads_dir, Some(&storage_ctx.storage), cli)?;
     let external_db_paths = config::external_project_db_paths(&config_layer, &beads_dir);
     let use_color = config::should_use_color(&config_layer);
     let max_width = if std::io::stdout().is_terminal() {
@@ -65,8 +64,9 @@ pub fn execute(
     info!("Fetching ready issues");
     debug!(filters = ?filters, sort = ?sort_policy, "Applied ready filters");
 
-    // Get ready issues from storage (blocked cache only)
-    let mut ready_issues = storage.get_ready_issues(&filters, sort_policy)?;
+    // Get ready issues from storage (blocked cache only; needs &mut for lazy cache rebuild)
+    let mut ready_issues = storage_ctx.storage.get_ready_issues(&filters, sort_policy)?;
+    let storage = &storage_ctx.storage;
 
     let external_statuses =
         storage.resolve_external_dependency_statuses(&external_db_paths, true)?;

--- a/src/cli/commands/stats.rs
+++ b/src/cli/commands/stats.rs
@@ -32,9 +32,8 @@ pub fn execute(
     outer_ctx: &OutputContext,
 ) -> Result<()> {
     let beads_dir = config::discover_beads_dir_with_cli(cli)?;
-    let storage_ctx = config::open_storage_with_cli(&beads_dir, cli)?;
-    let storage = &storage_ctx.storage;
-    let config_layer = config::load_config(&beads_dir, Some(storage), cli)?;
+    let mut storage_ctx = config::open_storage_with_cli(&beads_dir, cli)?;
+    let config_layer = config::load_config(&beads_dir, Some(&storage_ctx.storage), cli)?;
     let use_color = config::should_use_color(&config_layer);
     let output_format = resolve_output_format_basic(args.format, outer_ctx.is_json(), args.robot);
     let quiet = cli.quiet.unwrap_or(false);
@@ -48,12 +47,12 @@ pub fn execute(
         include_templates: true,
         ..Default::default()
     };
-    let all_issues = storage.list_issues(&all_filters)?;
+    let all_issues = storage_ctx.storage.list_issues(&all_filters)?;
 
     debug!(total = all_issues.len(), "Loaded all issues for stats");
 
     // Compute summary counts
-    let summary = compute_summary(storage, &all_issues)?;
+    let summary = compute_summary(&mut storage_ctx.storage, &all_issues)?;
 
     // Compute breakdowns if requested
     let mut breakdowns = Vec::new();
@@ -68,7 +67,7 @@ pub fn execute(
         breakdowns.push(compute_assignee_breakdown(&all_issues));
     }
     if args.by_label {
-        breakdowns.push(compute_label_breakdown(storage, &all_issues)?);
+        breakdowns.push(compute_label_breakdown(&storage_ctx.storage, &all_issues)?);
     }
 
     // Compute recent activity by default (matches bd behavior).
@@ -112,7 +111,7 @@ pub fn execute(
 /// Compute summary statistics.
 #[allow(clippy::cast_precision_loss)]
 fn compute_summary(
-    storage: &SqliteStorage,
+    storage: &mut SqliteStorage,
     issues: &[crate::model::Issue],
 ) -> Result<StatsSummary> {
     let mut open = 0;
@@ -820,7 +819,7 @@ mod tests {
         storage.create_issue(&third_issue, "tester").unwrap();
 
         let all_issues = vec![first_issue, second_issue, third_issue];
-        let summary = compute_summary(&storage, &all_issues).unwrap();
+        let summary = compute_summary(&mut storage, &all_issues).unwrap();
 
         assert_eq!(summary.total_issues, 3);
         assert_eq!(summary.open_issues, 1);

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -21,6 +21,8 @@ pub struct SqliteStorage {
     conn: Connection,
     /// Track mutations to trigger periodic WAL checkpoints.
     mutation_count: u32,
+    /// Lazy rebuild: set when deps change, cleared on next cache read.
+    blocked_cache_dirty: bool,
 }
 
 /// Context for a mutation operation, tracking side effects.
@@ -113,7 +115,7 @@ impl SqliteStorage {
         if user_version < CURRENT_SCHEMA_VERSION {
             apply_schema(&conn)?;
         }
-        Ok(Self { conn, mutation_count: 0 })
+        Ok(Self { conn, mutation_count: 0, blocked_cache_dirty: false })
     }
 
     /// Open an in-memory database for testing.
@@ -124,7 +126,7 @@ impl SqliteStorage {
     pub fn open_memory() -> Result<Self> {
         let conn = Connection::open(":memory:")?;
         apply_schema(&conn)?;
-        Ok(Self { conn, mutation_count: 0 })
+        Ok(Self { conn, mutation_count: 0, blocked_cache_dirty: false })
     }
 
     /// Attempt a WAL checkpoint (TRUNCATE mode) to flush WAL back to the main
@@ -134,6 +136,51 @@ impl SqliteStorage {
         if let Err(e) = self.conn.execute("PRAGMA wal_checkpoint(TRUNCATE)") {
             tracing::debug!(error = %e, "WAL checkpoint failed (non-fatal, will retry later)");
         }
+    }
+
+    /// Begin a raw (non-IMMEDIATE) transaction for batching many writes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database is already in a transaction.
+    pub fn begin_raw_transaction(&mut self) -> Result<()> {
+        self.conn.execute("BEGIN")?;
+        Ok(())
+    }
+
+    /// Commit a raw transaction started with `begin_raw_transaction`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is no active transaction.
+    pub fn commit_raw_transaction(&mut self) -> Result<()> {
+        self.conn.execute("COMMIT")?;
+        Ok(())
+    }
+
+    /// Rollback a raw transaction. Errors are silently ignored.
+    pub fn rollback_raw_transaction(&mut self) {
+        let _ = self.conn.execute("ROLLBACK");
+    }
+
+    /// Rebuild the blocked-issues cache if it has been marked dirty.
+    ///
+    /// Call this before any read that consults `blocked_issues_cache`.
+    fn ensure_blocked_cache(&mut self) -> Result<()> {
+        if self.blocked_cache_dirty {
+            self.conn.execute("BEGIN")?;
+            match Self::rebuild_blocked_cache_impl(&self.conn) {
+                Ok(_) => {
+                    self.conn.execute("COMMIT")?;
+                    self.blocked_cache_dirty = false;
+                }
+                Err(e) => {
+                    let _ = self.conn.execute("ROLLBACK");
+                    return Err(e);
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Get audit events for a specific issue.
@@ -206,9 +253,9 @@ impl SqliteStorage {
                         )?;
                     }
 
-                    // Rebuild blocked cache inside the transaction if needed
+                    // Mark blocked cache dirty — rebuilt lazily on next read
                     if ctx.invalidate_blocked_cache {
-                        Self::rebuild_blocked_cache_impl(&self.conn)?;
+                        self.blocked_cache_dirty = true;
                     }
 
                     // Try to commit
@@ -1157,10 +1204,11 @@ impl SqliteStorage {
     /// Returns an error if the database query fails.
     #[allow(clippy::too_many_lines)]
     pub fn get_ready_issues(
-        &self,
+        &mut self,
         filters: &ReadyFilters,
         sort: ReadySortPolicy,
     ) -> Result<Vec<Issue>> {
+        self.ensure_blocked_cache()?;
         let mut sql = String::from(
             r"SELECT id, content_hash, title, description, design, acceptance_criteria, notes,
                      status, priority, issue_type, assignee, owner, estimated_minutes,
@@ -1325,7 +1373,8 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
-    pub fn get_blocked_ids(&self) -> Result<HashSet<String>> {
+    pub fn get_blocked_ids(&mut self) -> Result<HashSet<String>> {
+        self.ensure_blocked_cache()?;
         let rows = self
             .conn
             .query("SELECT issue_id FROM blocked_issues_cache")?;
@@ -1374,7 +1423,8 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
-    pub fn is_blocked(&self, issue_id: &str) -> Result<bool> {
+    pub fn is_blocked(&mut self, issue_id: &str) -> Result<bool> {
+        self.ensure_blocked_cache()?;
         let rows = self.conn.query_with_params(
             "SELECT 1 FROM blocked_issues_cache WHERE issue_id = ? LIMIT 1",
             &[SqliteValue::from(issue_id)],
@@ -1391,7 +1441,8 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
-    pub fn get_blockers(&self, issue_id: &str) -> Result<Vec<String>> {
+    pub fn get_blockers(&mut self, issue_id: &str) -> Result<Vec<String>> {
+        self.ensure_blocked_cache()?;
         let json_opt: Option<String> = self
             .conn
             .query_row_with_params(
@@ -1434,13 +1485,14 @@ impl SqliteStorage {
     /// Returns an error if the database operation fails.
     #[allow(clippy::too_many_lines)]
     pub fn rebuild_blocked_cache(&mut self, force_rebuild: bool) -> Result<usize> {
-        if !force_rebuild {
+        if !force_rebuild && !self.blocked_cache_dirty {
             return Ok(0);
         }
         self.conn.execute("BEGIN")?;
         match Self::rebuild_blocked_cache_impl(&self.conn) {
             Ok(count) => {
                 self.conn.execute("COMMIT")?;
+                self.blocked_cache_dirty = false;
                 Ok(count)
             }
             Err(e) => {
@@ -1452,162 +1504,130 @@ impl SqliteStorage {
 
     #[allow(clippy::too_many_lines)]
     fn rebuild_blocked_cache_impl(conn: &Connection) -> Result<usize> {
-        const MAX_DEPTH: i32 = 50;
+        const MAX_DEPTH: usize = 50;
 
         // Clear existing cache
         conn.execute("DELETE FROM blocked_issues_cache")?;
 
-        // Find all issues that are blocked by a dependency
-        let mut blocked_issues_map: std::collections::HashMap<String, Vec<String>> =
-            std::collections::HashMap::new();
-        {
-            let rows = conn.query(
-                r"SELECT DISTINCT d.issue_id, d.depends_on_id || ':' || COALESCE(i.status, 'unknown')
-                  FROM dependencies d
-                  LEFT JOIN issues i ON d.depends_on_id = i.id
-                  WHERE d.type IN ('blocks', 'conditional-blocks', 'waits-for')
-                    AND (
-                      i.status NOT IN ('closed', 'tombstone')
-                      OR (i.id IS NULL AND d.depends_on_id NOT LIKE 'external:%')
-                    )",
-            )?;
+        // --- Load all data into Rust for in-memory computation ---
 
+        // Load issue statuses (simple single-table query, no JOINs)
+        let mut issue_status: HashMap<String, String> = HashMap::new();
+        {
+            let rows = conn.query("SELECT id, status FROM issues")?;
             for row in &rows {
-                let issue_id = row
-                    .get(0)
-                    .and_then(SqliteValue::as_text)
-                    .unwrap_or("")
-                    .to_string();
-                let blocker_ref = row
-                    .get(1)
-                    .and_then(SqliteValue::as_text)
-                    .unwrap_or("")
-                    .to_string();
-                blocked_issues_map
-                    .entry(issue_id)
-                    .or_default()
-                    .push(blocker_ref);
+                let id = row.get(0).and_then(SqliteValue::as_text).unwrap_or("").to_string();
+                let status = row.get(1).and_then(SqliteValue::as_text).unwrap_or("unknown").to_string();
+                issue_status.insert(id, status);
             }
         }
 
-        // Insert blocked issues into cache
-        let mut count = 0;
-        for (issue_id, blockers) in blocked_issues_map {
-            if blockers.is_empty() {
+        // Load all dependencies (simple single-table query, no JOINs)
+        let mut all_deps: Vec<(String, String, String)> = Vec::new();
+        {
+            let rows = conn.query("SELECT issue_id, depends_on_id, type FROM dependencies")?;
+            for row in &rows {
+                let issue_id = row.get(0).and_then(SqliteValue::as_text).unwrap_or("").to_string();
+                let depends_on = row.get(1).and_then(SqliteValue::as_text).unwrap_or("").to_string();
+                let dep_type = row.get(2).and_then(SqliteValue::as_text).unwrap_or("").to_string();
+                all_deps.push((issue_id, depends_on, dep_type));
+            }
+        }
+
+        // --- Phase 1: Direct blocking deps ---
+        let mut blocked_map: HashMap<String, Vec<String>> = HashMap::new();
+        for (issue_id, depends_on, dep_type) in &all_deps {
+            if !matches!(dep_type.as_str(), "blocks" | "conditional-blocks" | "waits-for") {
                 continue;
             }
-            let blockers_json =
-                serde_json::to_string(&blockers).unwrap_or_else(|_| "[]".to_string());
-            conn.execute_with_params(
-                "INSERT INTO blocked_issues_cache (issue_id, blocked_by) VALUES (?, ?)",
-                &[
-                    SqliteValue::from(issue_id),
-                    SqliteValue::from(blockers_json),
-                ],
-            )?;
-            count += 1;
-        }
-
-        // Mark children of deferred epics as blocked.
-        // A deferred parent effectively blocks all of its children, even though
-        // there is no explicit blocks/waits-for dependency.  We find every
-        // issue whose parent (via a parent-child dependency) has status = 'deferred'
-        // and insert it into the blocked cache so it won't appear as "ready."
-        {
-            let rows = conn.query(
-                r"SELECT DISTINCT d.issue_id, d.depends_on_id
-                  FROM dependencies d
-                  INNER JOIN issues i ON d.depends_on_id = i.id
-                  WHERE d.type = 'parent-child'
-                    AND i.status = 'deferred'
-                    AND NOT EXISTS (
-                        SELECT 1 FROM blocked_issues_cache WHERE issue_id = d.issue_id
-                    )",
-            )?;
-
-            for row in &rows {
-                let issue_id = row
-                    .get(0)
-                    .and_then(SqliteValue::as_text)
-                    .unwrap_or("")
-                    .to_string();
-                let parent_id = row
-                    .get(1)
-                    .and_then(SqliteValue::as_text)
-                    .unwrap_or("")
-                    .to_string();
-                let blockers = vec![format!("{parent_id}:deferred")];
-                let blockers_json =
-                    serde_json::to_string(&blockers).unwrap_or_else(|_| "[]".to_string());
-                conn.execute_with_params(
-                    "INSERT INTO blocked_issues_cache (issue_id, blocked_by) VALUES (?, ?)",
-                    &[
-                        SqliteValue::from(issue_id),
-                        SqliteValue::from(blockers_json),
-                    ],
-                )?;
-                count += 1;
-            }
-        }
-
-        // Now handle transitive blocking via parent-child relationships
-        let mut depth = 0;
-        loop {
-            if depth >= MAX_DEPTH {
-                tracing::warn!(
-                    "Transitive blocked cache rebuild hit max depth {}",
-                    MAX_DEPTH
-                );
-                break;
-            }
-
-            let newly_blocked: Vec<(String, String)> = {
-                let rows = conn.query(
-                    r"SELECT DISTINCT d.issue_id, d.depends_on_id
-                      FROM dependencies d
-                      INNER JOIN blocked_issues_cache bc ON d.depends_on_id = bc.issue_id
-                      WHERE d.type = 'parent-child'
-                        AND NOT EXISTS (SELECT 1 FROM blocked_issues_cache WHERE issue_id = d.issue_id)",
-                )?;
-
-                rows.iter()
-                    .filter_map(|row| {
-                        let id = row.get(0).and_then(SqliteValue::as_text)?.to_string();
-                        let parent = row.get(1).and_then(SqliteValue::as_text)?.to_string();
-                        Some((id, parent))
-                    })
-                    .collect()
+            let dep_status = issue_status.get(depends_on).map(String::as_str);
+            let is_blocking = match dep_status {
+                Some("closed" | "tombstone") => false,
+                Some(_) => true,
+                // Unknown dep: blocking unless external
+                None => !depends_on.starts_with("external:"),
             };
+            if is_blocking {
+                let label = format!("{}:{}", depends_on, dep_status.unwrap_or("unknown"));
+                blocked_map.entry(issue_id.clone()).or_default().push(label);
+            }
+        }
+
+        // --- Phase 2: Children of deferred parents ---
+        // Build parent-child map: child_id -> [parent_ids]
+        let mut parent_child: HashMap<String, Vec<String>> = HashMap::new();
+        for (issue_id, depends_on, dep_type) in &all_deps {
+            if dep_type == "parent-child" {
+                parent_child.entry(issue_id.clone()).or_default().push(depends_on.clone());
+            }
+        }
+
+        for (child_id, parents) in &parent_child {
+            if blocked_map.contains_key(child_id) {
+                continue;
+            }
+            for parent_id in parents {
+                if issue_status.get(parent_id).map(String::as_str) == Some("deferred") {
+                    blocked_map
+                        .entry(child_id.clone())
+                        .or_default()
+                        .push(format!("{parent_id}:deferred"));
+                }
+            }
+        }
+
+        // --- Phase 3: Transitive blocking via parent-child ---
+        // If a parent is blocked, its children are transitively blocked
+        let blocked_set: HashSet<String> = blocked_map.keys().cloned().collect();
+        let mut blocked_set = blocked_set;
+
+        for depth in 0..MAX_DEPTH {
+            let mut newly_blocked: HashMap<String, Vec<String>> = HashMap::new();
+
+            for (child_id, parents) in &parent_child {
+                if blocked_set.contains(child_id) {
+                    continue;
+                }
+                for parent_id in parents {
+                    if blocked_set.contains(parent_id) {
+                        newly_blocked
+                            .entry(child_id.clone())
+                            .or_default()
+                            .push(format!("{parent_id}:parent-blocked"));
+                    }
+                }
+            }
 
             if newly_blocked.is_empty() {
                 break;
             }
 
-            let mut issue_blockers: std::collections::HashMap<String, Vec<String>> =
-                std::collections::HashMap::new();
-            for (issue_id, parent_id) in newly_blocked {
-                issue_blockers.entry(issue_id).or_default().push(parent_id);
+            if depth == MAX_DEPTH - 1 {
+                tracing::warn!("Transitive blocked cache rebuild hit max depth {MAX_DEPTH}");
             }
 
-            for (issue_id, parents) in issue_blockers {
-                let blockers: Vec<String> = parents
-                    .into_iter()
-                    .map(|p| format!("{p}:parent-blocked"))
-                    .collect();
-                let blockers_json =
-                    serde_json::to_string(&blockers).unwrap_or_else(|_| "[]".to_string());
-
-                conn.execute_with_params(
-                    "INSERT INTO blocked_issues_cache (issue_id, blocked_by) VALUES (?, ?)",
-                    &[
-                        SqliteValue::from(issue_id),
-                        SqliteValue::from(blockers_json),
-                    ],
-                )?;
-                count += 1;
+            for (id, blockers) in newly_blocked {
+                blocked_set.insert(id.clone());
+                blocked_map.entry(id).or_default().extend(blockers);
             }
+        }
 
-            depth += 1;
+        // --- Write results to DB in bulk ---
+        let mut count = 0;
+        for (issue_id, blockers) in &blocked_map {
+            if blockers.is_empty() {
+                continue;
+            }
+            let blockers_json =
+                serde_json::to_string(blockers).unwrap_or_else(|_| "[]".to_string());
+            conn.execute_with_params(
+                "INSERT INTO blocked_issues_cache (issue_id, blocked_by) VALUES (?, ?)",
+                &[
+                    SqliteValue::from(issue_id.as_str()),
+                    SqliteValue::from(blockers_json),
+                ],
+            )?;
+            count += 1;
         }
 
         tracing::debug!(blocked_count = count, "Rebuilt blocked issues cache");
@@ -1619,7 +1639,8 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if the database query fails.
-    pub fn get_blocked_issues(&self) -> Result<Vec<(Issue, Vec<String>)>> {
+    pub fn get_blocked_issues(&mut self) -> Result<Vec<(Issue, Vec<String>)>> {
+        self.ensure_blocked_cache()?;
         let rows = self.conn.query(
             r"SELECT i.id, i.content_hash, i.title, i.description, i.design, i.acceptance_criteria, i.notes,
                      i.status, i.priority, i.issue_type, i.assignee, i.owner, i.estimated_minutes,
@@ -4989,20 +5010,12 @@ mod tests {
             .add_dependency("bd-c1", "bd-b1", "related", "tester")
             .unwrap();
 
-        // Cache should be rebuilt - since "related" is not a blocking type,
-        // bd-c1 should no longer be in the blocked cache (the manually
-        // inserted entry gets cleared and not replaced)
-        let count = storage
-            .conn
-            .query_row_with_params(
-                "SELECT count(*) FROM blocked_issues_cache WHERE issue_id = ?",
-                &[SqliteValue::from("bd-c1")],
-            )
-            .unwrap()
-            .get(0)
-            .and_then(SqliteValue::as_integer)
-            .unwrap_or(0);
-        assert_eq!(count, 0);
+        // Cache is lazily rebuilt — trigger it by reading blocked status
+        let is_blocked = storage.is_blocked("bd-c1").unwrap();
+
+        // Since "related" is not a blocking type, bd-c1 should no longer be
+        // blocked (the manually inserted entry gets cleared and not replaced)
+        assert!(!is_blocked);
     }
 
     #[test]

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -2385,22 +2385,44 @@ pub fn import_from_jsonl(
         }
     }
 
-    // Phase 3: Execute Actions
+    // Phase 3: Execute Actions (batched into transactions to avoid per-statement fsyncs)
+    const IMPORT_BATCH_SIZE: usize = 50;
     let progress = create_progress_bar(
         import_ops.len() as u64,
         "Importing issues",
         config.show_progress,
     );
 
-    for (issue, action) in import_ops {
-        process_import_action(storage, &action, &issue, &mut result)?;
-        progress.inc(1);
+    for chunk in import_ops.chunks(IMPORT_BATCH_SIZE) {
+        storage.begin_raw_transaction()?;
+        let batch_result = (|| -> Result<()> {
+            for (issue, action) in chunk {
+                process_import_action(storage, action, issue, &mut result)?;
+                progress.inc(1);
+            }
+            Ok(())
+        })();
+
+        match batch_result {
+            Ok(()) => storage.commit_raw_transaction()?,
+            Err(e) => {
+                storage.rollback_raw_transaction();
+                return Err(e);
+            }
+        }
     }
     progress.finish_with_message("Import complete");
 
-    // Restore export hashes for imported issues
+    // Restore export hashes for imported issues (in its own transaction)
     if !new_export_hashes.is_empty() {
-        storage.set_export_hashes(&new_export_hashes)?;
+        storage.begin_raw_transaction()?;
+        match storage.set_export_hashes(&new_export_hashes) {
+            Ok(_) => storage.commit_raw_transaction()?,
+            Err(e) => {
+                storage.rollback_raw_transaction();
+                return Err(e);
+            }
+        }
     }
 
     // Step 10: Refresh blocked cache

--- a/tests/storage_blocked_cache.rs
+++ b/tests/storage_blocked_cache.rs
@@ -19,7 +19,7 @@ use common::{fixtures, test_db};
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn blocked_ids(storage: &SqliteStorage) -> Vec<String> {
+fn blocked_ids(storage: &mut SqliteStorage) -> Vec<String> {
     storage
         .get_blocked_issues()
         .unwrap()
@@ -28,7 +28,7 @@ fn blocked_ids(storage: &SqliteStorage) -> Vec<String> {
         .collect()
 }
 
-fn ready_ids(storage: &SqliteStorage) -> Vec<String> {
+fn ready_ids(storage: &mut SqliteStorage) -> Vec<String> {
     storage
         .get_ready_issues(&ReadyFilters::default(), ReadySortPolicy::Priority)
         .unwrap()
@@ -69,7 +69,7 @@ fn reopen_blocker_re_blocks_dependent() {
 
     // Dependent should be blocked
     assert!(
-        blocked_ids(&storage).contains(&dependent.id),
+        blocked_ids(&mut storage).contains(&dependent.id),
         "dependent should be blocked initially"
     );
 
@@ -78,7 +78,7 @@ fn reopen_blocker_re_blocks_dependent() {
         .update_issue(&blocker.id, &status_update(Status::Closed), "tester")
         .unwrap();
     assert!(
-        !blocked_ids(&storage).contains(&dependent.id),
+        !blocked_ids(&mut storage).contains(&dependent.id),
         "dependent should be unblocked after closing blocker"
     );
 
@@ -87,7 +87,7 @@ fn reopen_blocker_re_blocks_dependent() {
         .update_issue(&blocker.id, &status_update(Status::Open), "tester")
         .unwrap();
     assert!(
-        blocked_ids(&storage).contains(&dependent.id),
+        blocked_ids(&mut storage).contains(&dependent.id),
         "dependent should be re-blocked after reopening blocker"
     );
 }
@@ -118,7 +118,7 @@ fn chain_dependency_blocks_downstream() {
         .add_dependency(&c.id, &b.id, DependencyType::Blocks.as_str(), "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(ids.contains(&b.id), "B should be blocked by A");
     assert!(ids.contains(&c.id), "C should be blocked by B");
 
@@ -127,7 +127,7 @@ fn chain_dependency_blocks_downstream() {
         .update_issue(&a.id, &status_update(Status::Closed), "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(!ids.contains(&b.id), "B should be unblocked after A closed");
     assert!(ids.contains(&c.id), "C should still be blocked by open B");
 
@@ -136,7 +136,7 @@ fn chain_dependency_blocks_downstream() {
         .update_issue(&b.id, &status_update(Status::Closed), "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(!ids.contains(&c.id), "C should be unblocked after B closed");
 }
 
@@ -173,14 +173,14 @@ fn multiple_blockers_partial_close() {
         )
         .unwrap();
 
-    assert!(blocked_ids(&storage).contains(&dependent.id));
+    assert!(blocked_ids(&mut storage).contains(&dependent.id));
 
     // Close only blocker1 → still blocked by blocker2
     storage
         .update_issue(&blocker1.id, &status_update(Status::Closed), "tester")
         .unwrap();
     assert!(
-        blocked_ids(&storage).contains(&dependent.id),
+        blocked_ids(&mut storage).contains(&dependent.id),
         "still blocked by blocker2"
     );
 
@@ -189,7 +189,7 @@ fn multiple_blockers_partial_close() {
         .update_issue(&blocker2.id, &status_update(Status::Closed), "tester")
         .unwrap();
     assert!(
-        !blocked_ids(&storage).contains(&dependent.id),
+        !blocked_ids(&mut storage).contains(&dependent.id),
         "unblocked after all blockers closed"
     );
 }
@@ -222,7 +222,7 @@ fn mixed_dependency_types_all_block() {
         .add_dependency(&target.id, &b3.id, "waits-for", "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(
         ids.contains(&target.id),
         "target should be blocked by all three dependency types"
@@ -236,7 +236,7 @@ fn mixed_dependency_types_all_block() {
     }
 
     assert!(
-        !blocked_ids(&storage).contains(&target.id),
+        !blocked_ids(&mut storage).contains(&target.id),
         "target unblocked after all mixed deps closed"
     );
 }
@@ -264,7 +264,7 @@ fn closing_blocked_issue_removes_from_cache() {
         )
         .unwrap();
 
-    assert!(blocked_ids(&storage).contains(&blocked_issue.id));
+    assert!(blocked_ids(&mut storage).contains(&blocked_issue.id));
 
     // Close the blocked issue itself (not the blocker)
     storage
@@ -273,7 +273,7 @@ fn closing_blocked_issue_removes_from_cache() {
 
     // Closed issues should not appear in blocked cache
     // (blocked cache only tracks open/in_progress issues)
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(
         !ids.contains(&blocked_issue.id),
         "closed issue should not appear in blocked cache"
@@ -303,7 +303,7 @@ fn delete_issue_cleans_cache() {
         )
         .unwrap();
 
-    assert!(blocked_ids(&storage).contains(&blocked_issue.id));
+    assert!(blocked_ids(&mut storage).contains(&blocked_issue.id));
 
     // Delete the blocker → blocked_issue should become unblocked
     // (tombstoned issues are terminal, so dependency no longer active)
@@ -311,7 +311,7 @@ fn delete_issue_cleans_cache() {
         .delete_issue(&blocker.id, "tester", "test cleanup", None)
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(
         !ids.contains(&blocked_issue.id),
         "deleting blocker should unblock dependent"
@@ -351,14 +351,14 @@ fn remove_all_dependencies_clears_cache() {
         )
         .unwrap();
 
-    assert!(blocked_ids(&storage).contains(&target.id));
+    assert!(blocked_ids(&mut storage).contains(&target.id));
 
     storage
         .remove_all_dependencies(&target.id, "tester")
         .unwrap();
 
     assert!(
-        !blocked_ids(&storage).contains(&target.id),
+        !blocked_ids(&mut storage).contains(&target.id),
         "removing all deps should unblock issue"
     );
 }
@@ -394,7 +394,7 @@ fn parent_child_transitive_blocking() {
         .add_dependency(&child.id, &parent.id, "parent-child", "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(ids.contains(&parent.id), "parent blocked by blocker");
     assert!(
         ids.contains(&child.id),
@@ -406,7 +406,7 @@ fn parent_child_transitive_blocking() {
         .update_issue(&blocker.id, &status_update(Status::Closed), "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(!ids.contains(&parent.id), "parent unblocked");
     assert!(!ids.contains(&child.id), "child transitively unblocked");
 }
@@ -440,7 +440,7 @@ fn remove_parent_unblocks_child() {
         .unwrap();
 
     assert!(
-        blocked_ids(&storage).contains(&child.id),
+        blocked_ids(&mut storage).contains(&child.id),
         "child blocked via parent"
     );
 
@@ -450,7 +450,7 @@ fn remove_parent_unblocks_child() {
         .unwrap();
 
     assert!(
-        !blocked_ids(&storage).contains(&child.id),
+        !blocked_ids(&mut storage).contains(&child.id),
         "child should be unblocked after parent link removed"
     );
 }
@@ -480,8 +480,8 @@ fn ready_and_blocked_are_disjoint() {
         )
         .unwrap();
 
-    let ready = ready_ids(&storage);
-    let blocked = blocked_ids(&storage);
+    let ready = ready_ids(&mut storage);
+    let blocked = blocked_ids(&mut storage);
 
     // Blocked issues must not appear in ready list
     for id in &blocked {
@@ -610,7 +610,7 @@ fn in_progress_blocker_still_blocks() {
         .unwrap();
 
     assert!(
-        blocked_ids(&storage).contains(&dependent.id),
+        blocked_ids(&mut storage).contains(&dependent.id),
         "in_progress blocker should still block dependent"
     );
 }
@@ -694,7 +694,7 @@ fn deep_parent_child_chain_blocking() {
         .add_dependency(&leaf.id, &p3.id, "parent-child", "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(ids.contains(&p1.id), "p1 directly blocked");
     assert!(ids.contains(&p2.id), "p2 transitively blocked");
     assert!(ids.contains(&p3.id), "p3 transitively blocked");
@@ -705,7 +705,7 @@ fn deep_parent_child_chain_blocking() {
         .update_issue(&blocker.id, &status_update(Status::Closed), "tester")
         .unwrap();
 
-    let ids = blocked_ids(&storage);
+    let ids = blocked_ids(&mut storage);
     assert!(!ids.contains(&p1.id), "p1 unblocked");
     assert!(!ids.contains(&p2.id), "p2 unblocked");
     assert!(!ids.contains(&p3.id), "p3 unblocked");

--- a/tests/storage_deps.rs
+++ b/tests/storage_deps.rs
@@ -12,7 +12,7 @@ use beads_rust::model::{DependencyType, EventType, Status};
 use beads_rust::storage::{ReadyFilters, ReadySortPolicy, SqliteStorage};
 use common::{fixtures, test_db};
 
-fn blocked_ids_for(storage: &SqliteStorage) -> Vec<String> {
+fn blocked_ids_for(storage: &mut SqliteStorage) -> Vec<String> {
     storage
         .get_blocked_issues()
         .unwrap()
@@ -685,7 +685,7 @@ fn deep_hierarchy_transitive_blocked() {
     // Need to rebuild blocked cache first
     storage.rebuild_blocked_cache(true).unwrap();
 
-    let blocked_ids = blocked_ids_for(&storage);
+    let blocked_ids = blocked_ids_for(&mut storage);
     // All issues except root should be blocked
     assert!(blocked_ids.contains(&l1.id));
     assert!(blocked_ids.contains(&l2.id));
@@ -783,7 +783,7 @@ fn diamond_pattern_blocked_propagation() {
     // Rebuild blocked cache
     storage.rebuild_blocked_cache(true).unwrap();
 
-    let blocked_ids = blocked_ids_for(&storage);
+    let blocked_ids = blocked_ids_for(&mut storage);
     // A, B, C are all blocked (depend on D which is open)
     assert!(blocked_ids.contains(&a.id));
     assert!(blocked_ids.contains(&b.id));
@@ -807,7 +807,7 @@ fn blocked_cache_invalidated_on_add_dependency() {
 
     // Initially no blocked issues
     storage.rebuild_blocked_cache(true).unwrap();
-    let initial_blocked = blocked_ids_for(&storage);
+    let initial_blocked = blocked_ids_for(&mut storage);
     assert!(!initial_blocked.contains(&blocked.id));
 
     // Add dependency - cache should be invalidated and rebuilt
@@ -821,7 +821,7 @@ fn blocked_cache_invalidated_on_add_dependency() {
         .unwrap();
 
     // After adding dependency, blocked should be in blocked cache
-    let after_blocked = blocked_ids_for(&storage);
+    let after_blocked = blocked_ids_for(&mut storage);
     assert!(after_blocked.contains(&blocked.id));
 }
 
@@ -846,7 +846,7 @@ fn blocked_cache_invalidated_on_remove_dependency() {
         .unwrap();
 
     // Blocked should be in cache
-    let before_blocked = blocked_ids_for(&storage);
+    let before_blocked = blocked_ids_for(&mut storage);
     assert!(before_blocked.contains(&blocked.id));
 
     // Remove dependency - cache should be invalidated
@@ -855,7 +855,7 @@ fn blocked_cache_invalidated_on_remove_dependency() {
         .unwrap();
 
     // After removing, blocked should not be in cache
-    let after_blocked = blocked_ids_for(&storage);
+    let after_blocked = blocked_ids_for(&mut storage);
     assert!(!after_blocked.contains(&blocked.id));
 }
 
@@ -879,7 +879,7 @@ fn blocked_cache_reflects_status_changes() {
         .unwrap();
 
     // Initially blocked (blocker is open)
-    let blocked_ids = blocked_ids_for(&storage);
+    let blocked_ids = blocked_ids_for(&mut storage);
     assert!(blocked_ids.contains(&blocked.id));
 
     // Close the blocker
@@ -892,7 +892,7 @@ fn blocked_cache_reflects_status_changes() {
         .unwrap();
 
     // After closing blocker, blocked should no longer be blocked
-    let blocked_ids = blocked_ids_for(&storage);
+    let blocked_ids = blocked_ids_for(&mut storage);
     assert!(!blocked_ids.contains(&blocked.id));
 }
 

--- a/tests/storage_ready.rs
+++ b/tests/storage_ready.rs
@@ -15,7 +15,7 @@ use common::{fixtures, test_db};
 // ============================================================================
 
 fn ready_ids(
-    storage: &SqliteStorage,
+    storage: &mut SqliteStorage,
     filters: &ReadyFilters,
     sort: ReadySortPolicy,
 ) -> Vec<String> {
@@ -52,7 +52,7 @@ fn ready_filter_by_assignee() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&issue1.id));
     assert!(!ids.contains(&issue2.id));
@@ -78,7 +78,7 @@ fn ready_filter_unassigned_only() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
     assert!(!ids.contains(&assigned.id));
     assert!(ids.contains(&unassigned1.id));
@@ -112,7 +112,7 @@ fn ready_filter_by_single_type() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&bug.id));
 }
@@ -140,7 +140,7 @@ fn ready_filter_by_multiple_types() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
     assert!(ids.contains(&bug.id));
     assert!(ids.contains(&feature.id));
@@ -174,7 +174,7 @@ fn ready_filter_by_single_priority() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&p0.id));
 }
@@ -206,7 +206,7 @@ fn ready_filter_by_multiple_priorities() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
     assert!(ids.contains(&p0.id));
     assert!(ids.contains(&p1.id));
@@ -238,7 +238,7 @@ fn ready_filter_by_labels_and_single() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&issue1.id));
 }
@@ -266,7 +266,7 @@ fn ready_filter_by_labels_and_multiple() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&issue1.id));
 }
@@ -292,7 +292,7 @@ fn ready_filter_by_labels_or() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
     assert!(ids.contains(&issue1.id));
     assert!(ids.contains(&issue2.id));
@@ -318,7 +318,7 @@ fn ready_filter_with_limit() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 3);
 }
 
@@ -337,7 +337,7 @@ fn ready_filter_limit_zero_returns_all() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 3);
 }
 
@@ -356,7 +356,7 @@ fn ready_filter_limit_greater_than_total() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
 }
 
@@ -384,7 +384,7 @@ fn ready_sort_policy_priority() {
     storage.create_issue(&p1, "tester").unwrap();
 
     let filters = ReadyFilters::default();
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Priority);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Priority);
 
     // Should be sorted by priority: P0, P1, P2
     assert_eq!(ids.len(), 3);
@@ -407,7 +407,7 @@ fn ready_sort_policy_oldest() {
     storage.create_issue(&third, "tester").unwrap();
 
     let filters = ReadyFilters::default();
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
 
     // Should be sorted by created_at ASC (oldest first)
     assert_eq!(ids.len(), 3);
@@ -441,7 +441,7 @@ fn ready_sort_policy_hybrid() {
     storage.create_issue(&p1, "tester").unwrap();
 
     let filters = ReadyFilters::default();
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Hybrid);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Hybrid);
 
     // Hybrid: P0/P1 first (by created_at), then P2+ (by created_at)
     // P0 and P1 should be in first two positions
@@ -487,7 +487,7 @@ fn ready_combined_assignee_and_type_filter() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&alice_bug.id));
 }
@@ -526,7 +526,7 @@ fn ready_combined_priority_and_label_filter() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 1);
     assert!(ids.contains(&p0_backend.id));
 }
@@ -569,7 +569,7 @@ fn ready_excludes_blocked_issues_with_filters() {
         ..Default::default()
     };
 
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
     assert_eq!(ids.len(), 2);
     assert!(ids.contains(&blocker.id));
     assert!(ids.contains(&unblocked_bug.id));
@@ -603,7 +603,7 @@ fn ready_includes_open_and_in_progress() {
     storage.create_issue(&deferred, "tester").unwrap();
 
     let filters = ReadyFilters::default();
-    let ids = ready_ids(&storage, &filters, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters, ReadySortPolicy::Oldest);
 
     assert!(ids.contains(&open.id));
     assert!(ids.contains(&in_progress.id));
@@ -635,7 +635,7 @@ fn ready_include_deferred_flag() {
         include_deferred: false,
         ..Default::default()
     };
-    let ids = ready_ids(&storage, &filters_no_deferred, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters_no_deferred, ReadySortPolicy::Oldest);
     assert!(ids.contains(&open_no_defer.id));
     // Open issue with future defer_until should be excluded
     assert!(!ids.contains(&open_with_defer.id));
@@ -645,7 +645,7 @@ fn ready_include_deferred_flag() {
         include_deferred: true,
         ..Default::default()
     };
-    let ids = ready_ids(&storage, &filters_with_deferred, ReadySortPolicy::Oldest);
+    let ids = ready_ids(&mut storage, &filters_with_deferred, ReadySortPolicy::Oldest);
     assert!(ids.contains(&open_no_defer.id));
     assert!(ids.contains(&open_with_defer.id));
 }


### PR DESCRIPTION
> **Note:** Per the README, I understand outside contributions aren't merged directly. Submitting this to illustrate the fixes — happy to have it reviewed by your AI tooling and addressed however you see fit.

## Problem

Three performance bottlenecks make `br sync --import-only` and batch `br create --parent` unusably slow at scale:

1. **Import does one fsync per SQL statement.** Each `process_import_action` runs raw `execute_with_params` (DELETE + INSERT per issue, plus labels, deps, comments). Every statement auto-commits with an fsync (~5ms on m4 mac mini). 550 issues × ~6 statements = 3300+ fsyncs = 15s+. At 1700+ issues, 10+ minutes.

2. **`rebuild_blocked_cache_impl` does iterative SQL JOINs via fsqlite fallback.** The transitive closure loop runs up to 50 iterations of `INNER JOIN blocked_issues_cache`. fsqlite routes these through `join_or_subquery_fallback` (in-memory materialization), and each iteration gets slower as the cache table grows. 500 issues took 50s+ in the cache rebuild alone.

3. **Cache rebuild runs inside every `mutate()`.** When `--parent` adds a `ParentChild` dep, `invalidate_cache()` triggers a full `rebuild_blocked_cache_impl` inside the transaction. N creates = N full rebuilds = O(N^2).

## Solutions

### 1. Batched transactions for import
Wrap Phase 3 in batched `BEGIN`/`COMMIT` (50 issues per batch). One fsync per batch instead of per statement. Batch size of 50 avoids fsqlite OOM on large imports while still providing ~60x fewer fsyncs.

### 2. In-memory blocked cache computation
Replace the iterative SQL JOIN loop in `rebuild_blocked_cache_impl` with Rust-side graph traversal:
- Load issue statuses and all dependencies with two simple single-table queries (no JOINs)
- Compute direct blocking, deferred-parent blocking, and transitive parent-child blocking in HashMaps
- Batch-insert results into `blocked_issues_cache`

### 3. Lazy cache invalidation
Instead of rebuilding inside every `mutate()`, set a `blocked_cache_dirty` flag. Rebuild on first read (`get_ready_issues`, `is_blocked`, `get_blocked_issues`, etc.). Explicit `rebuild_blocked_cache(true)` callers (sync, epic, defer commands) still work and clear the flag.

## Details

**Files changed:**

| File | What |
|------|------|
| `src/storage/sqlite.rs` | `blocked_cache_dirty` field, `begin/commit/rollback_raw_transaction()`, `ensure_blocked_cache()`, rewritten `rebuild_blocked_cache_impl`, `&self` → `&mut self` on 5 cache-reading methods |
| `src/sync/mod.rs` | Batched transaction loop around Phase 3 + export hashes |
| `src/cli/commands/{blocked,ready,stats}.rs` | Borrow adjustments for `&mut self` signatures |
| `tests/storage_{blocked_cache,deps,ready}.rs` | Update test helpers for `&mut` signatures |

**Signature change:** `get_ready_issues`, `get_blocked_ids`, `is_blocked`, `get_blockers`, `get_blocked_issues` changed from `&self` to `&mut self` to support lazy cache rebuild. All existing callers already held `&mut` references.

**Benchmarks (1716-issue dataset):**

| Phase | Before | After |
|-------|--------|-------|
| Import (Phase 3 inserts) | 10+ min | ~5s |
| `rebuild_blocked_cache` | ~50s | <1s |
| Total | 10+ min | ~6s |

A [1716-issue test file](https://github.com/cmaher/beads_rust/blob/testdata/bench-1716-issues/testdata/bench-1716-issues.jsonl) is available if you'd like to reproduce.

All 781 existing tests pass (4 pre-existing failures in defer/comment ordering tests unrelated to this change).