### PR TITLE
fix: refresh blocked_issues_cache after dependency changes

### DIFF
--- a/src/cli/commands/dep.rs
+++ b/src/cli/commands/dep.rs
@@ -173,6 +173,11 @@ fn dep_add(
 
     let added = storage.add_dependency(&issue_id, &depends_on_id, dep_type.as_str(), actor)?;
 
+    // Rebuild blocked cache after adding dependency
+    if added {
+        storage.rebuild_blocked_cache(true)?;
+    }
+
     if ctx.is_json() || ctx.is_toon() {
         let result = DepActionResult {
             status: if added { "ok" } else { "exists" }.to_string(),
@@ -240,6 +245,11 @@ fn dep_remove(
     };
 
     let removed = storage.remove_dependency(&issue_id, &depends_on_id, actor)?;
+
+    // Rebuild blocked cache after removing dependency
+    if removed {
+        storage.rebuild_blocked_cache(true)?;
+    }
 
     if ctx.is_json() || ctx.is_toon() {
         let result = DepActionResult {


### PR DESCRIPTION
## Summary

When adding or removing dependencies using `br dep add` or `br dep remove`, the `blocked_issues_cache` was not being rebuilt. This caused `br ready` to incorrectly show blocked issues as ready-to-work.

## Problem

The `br ready` command relies on a cached table `blocked_issues_cache` to filter out issues that are blocked by dependencies. However, after adding or removing dependencies via `br dep add` or `br dep remove`, this cache was not being updated, leading to stale results.

## Solution

This fix ensures the blocked cache is rebuilt immediately after dependency changes:

- After `br dep add`: rebuild cache if a dependency was successfully added
- After `br dep remove`: rebuild cache if a dependency was successfully removed

This ensures that `br ready` correctly filters out issues that are blocked by open dependencies.

## Changes

- `src/cli/commands/dep.rs`: Added `rebuild_blocked_cache(true)` calls after dependency add/remove operations

## Testing

1. Create issue A (no dependencies)
2. Create issue B with dependency on A
3. Run `br ready` - only issue A should appear
4. Verify with `br blocked` - issue B should appear as blocked

## Related

Fixes: `br ready` shows blocked issues as ready