### PR TITLE
Document RUST_LOG=error as the quiet br default

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ br ready --json  # Structured output for agents
 br show bd-abc123 --json
 ```
 
+For routine operator or agent use, prefer `RUST_LOG=error br ...` to suppress internal Rust dependency logs while preserving normal stdout/JSON output:
+
+```bash
+RUST_LOG=error br ready --json
+RUST_LOG=error br sync --flush-only
+```
+
 ### 5. Rich Terminal Output
 
 Interactive terminals get enhanced visual output:
@@ -475,6 +482,14 @@ br config edit
 | `BEADS_DB` | Override database path |
 | `BEADS_JSONL` | Override JSONL path (requires `--allow-external-jsonl`) |
 | `RUST_LOG` | Logging level (debug, info, warn, error) |
+
+Recommended default for normal CLI use:
+
+```bash
+export RUST_LOG=error
+```
+
+This keeps successful commands readable by suppressing low-level dependency logging. Remove or override it when debugging `br` internals.
 
 ---
 

--- a/docs/AGENT_INTEGRATION.md
+++ b/docs/AGENT_INTEGRATION.md
@@ -101,11 +101,13 @@ If you omit `--format` / `--json`, br can default the output format via env vars
 
 - `BR_OUTPUT_FORMAT` (highest precedence)
 - `TOON_DEFAULT_FORMAT` (fallback)
+- `RUST_LOG=error` (recommended for routine agent runs so stderr stays clean unless you're debugging internals)
 
 Example:
 
 ```bash
 export TOON_DEFAULT_FORMAT=toon
+export RUST_LOG=error
 br list --limit 5          # defaults to TOON
 br list --json --limit 5   # JSON always wins
 ```
@@ -381,6 +383,7 @@ br close bd-123 --quiet --json
 ```bash
 # Set actor for audit trail
 export BD_ACTOR="claude-agent"
+export RUST_LOG=error
 
 # Workflow
 br ready --json --limit 10
@@ -395,6 +398,7 @@ br sync --flush-only
 ```bash
 # Initialize in project
 br init --prefix cursor
+export RUST_LOG=error
 
 # Use with Cursor's tool system
 br ready --json

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -876,6 +876,14 @@ source ~/.bashrc
 | `NO_COLOR` | Disable colored output (any value) |
 | `RUST_LOG` | Logging level (debug, info, warn, error) |
 
+Recommended routine default:
+
+```bash
+export RUST_LOG=error
+```
+
+This keeps successful commands readable by suppressing low-level dependency logs. Override it with `debug`/`trace` when troubleshooting.
+
 ---
 
 ## JSON Output Schemas


### PR DESCRIPTION
## Summary
- document `RUST_LOG=error` as the recommended default for routine `br` operator/agent use
- add the recommendation to the README, agent integration guide, and CLI reference
- clarify that the override is for readable successful output and should be removed when debugging internals

## Why
In routine use, `br` commands can emit low-level Rust dependency logs to stderr even when the command succeeds. Setting `RUST_LOG=error` keeps normal stdout/JSON output readable without changing command behavior.

## Validation
- reviewed the docs diff locally
- confirmed `br ready --no-auto-import --json` still succeeds with `RUST_LOG=error`
