### PR TITLE
fix(storage): use INSERT OR REPLACE for blocked_issues_cache

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -2889,7 +2889,7 @@ impl SqliteStorage {
         let mut count = 0;
         for (issue_id, blockers_json) in entries {
             conn.execute_with_params(
-                "INSERT INTO blocked_issues_cache (issue_id, blocked_by, blocked_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
+                "INSERT OR REPLACE INTO blocked_issues_cache (issue_id, blocked_by, blocked_at) VALUES (?, ?, CURRENT_TIMESTAMP)",
                 &[
                     SqliteValue::from(issue_id.as_str()),
                     SqliteValue::from(blockers_json.as_str()),


### PR DESCRIPTION
Fixes UNIQUE constraint error on `blocked_issues_cache.issue_id` during `br update`.

The `insert_blocked_cache_entries` function used a bare `INSERT INTO` which fails if the row already exists. Changed to `INSERT OR REPLACE INTO` to make it idempotent.