### PR TITLE
feat: abbreviate long auto-derived issue ID prefixes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@ use crate::sync::{
     ExportConfig, ImportConfig, ImportResult, auto_flush, compute_jsonl_hash,
     export_to_jsonl_with_policy, finalize_export, import_from_jsonl, preflight_import,
 };
-use crate::util::id::{IdConfig, split_prefix_remainder};
+use crate::util::id::{IdConfig, abbreviate_prefix, split_prefix_remainder};
 use chrono::Utc;
 use fsqlite_error::FrankenError;
 use serde::{Deserialize, Serialize};
@@ -1379,7 +1379,7 @@ fn resolve_bootstrap_issue_prefix(
         .map(str::trim)
         .filter(|name| !name.is_empty())
     {
-        return Ok(name.to_string());
+        return Ok(abbreviate_prefix(name));
     }
 
     Ok("br".to_string())
@@ -3932,6 +3932,37 @@ routing:
         let prefix = resolve_bootstrap_issue_prefix(&bootstrap_layer, &beads_dir, &jsonl_path)
             .expect("prefix");
         assert_eq!(prefix, "cfg");
+    }
+
+    #[test]
+    fn resolve_bootstrap_issue_prefix_abbreviates_long_dir_name() {
+        let temp = TempDir::new().expect("tempdir");
+        // Simulate a repo with a long hyphenated name
+        let repo_dir = temp.path().join("acme-widgets");
+        let beads_dir = repo_dir.join(".beads");
+        let jsonl_path = beads_dir.join("issues.jsonl");
+        fs::create_dir_all(&beads_dir).expect("create beads dir");
+        fs::write(&jsonl_path, "").expect("write empty jsonl");
+
+        let bootstrap_layer = ConfigLayer::default();
+        let prefix = resolve_bootstrap_issue_prefix(&bootstrap_layer, &beads_dir, &jsonl_path)
+            .expect("prefix");
+        assert_eq!(prefix, "aw");
+    }
+
+    #[test]
+    fn resolve_bootstrap_issue_prefix_keeps_short_dir_name() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo_dir = temp.path().join("myrepo");
+        let beads_dir = repo_dir.join(".beads");
+        let jsonl_path = beads_dir.join("issues.jsonl");
+        fs::create_dir_all(&beads_dir).expect("create beads dir");
+        fs::write(&jsonl_path, "").expect("write empty jsonl");
+
+        let bootstrap_layer = ConfigLayer::default();
+        let prefix = resolve_bootstrap_issue_prefix(&bootstrap_layer, &beads_dir, &jsonl_path)
+            .expect("prefix");
+        assert_eq!(prefix, "myrepo");
     }
 
     #[test]

--- a/src/util/id.rs
+++ b/src/util/id.rs
@@ -10,6 +10,31 @@ pub const MAX_ID_PREFIX_LEN: usize = 64;
 pub const MAX_ID_HASH_LEN: usize = 40;
 pub const MAX_ID_LENGTH: usize = MAX_ID_PREFIX_LEN + 1 + MAX_ID_HASH_LEN;
 
+/// Maximum length for an auto-derived prefix before abbreviation kicks in.
+pub const AUTO_PREFIX_MAX_LEN: usize = 6;
+
+/// Abbreviate a long prefix by taking the first letter of each hyphen-separated
+/// word (e.g. `acme-widgets` -> `aw`, `my-cool-project` -> `mcp`).
+/// If the result is only 1 character, use the first 3 characters of the original instead.
+/// Prefixes at or below `AUTO_PREFIX_MAX_LEN` are returned unchanged.
+#[must_use]
+pub fn abbreviate_prefix(name: &str) -> String {
+    if name.len() <= AUTO_PREFIX_MAX_LEN {
+        return name.to_string();
+    }
+    let initials: String = name
+        .split('-')
+        .filter(|w| !w.is_empty())
+        .filter_map(|w| w.chars().next())
+        .collect();
+    if initials.len() <= 1 {
+        // Single word longer than AUTO_PREFIX_MAX_LEN: take first 3 chars
+        name.chars().take(3).collect()
+    } else {
+        initials
+    }
+}
+
 /// Default ID generation configuration.
 #[derive(Debug, Clone)]
 pub struct IdConfig {
@@ -1249,5 +1274,34 @@ mod tests {
             parse_id(&good_id).is_ok(),
             "Fixed fallback format should parse correctly"
         );
+    }
+
+    // ========================================================================
+    // Prefix Abbreviation Tests
+    // ========================================================================
+
+    #[test]
+    fn test_abbreviate_prefix_short_unchanged() {
+        assert_eq!(abbreviate_prefix("br"), "br");
+        assert_eq!(abbreviate_prefix("abcdef"), "abcdef"); // exactly 6
+    }
+
+    #[test]
+    fn test_abbreviate_prefix_multi_word() {
+        assert_eq!(abbreviate_prefix("acme-widgets"), "aw");
+        assert_eq!(abbreviate_prefix("my-cool-project"), "mcp");
+        assert_eq!(abbreviate_prefix("a-b-c-d-e-f-g"), "abcdefg");
+    }
+
+    #[test]
+    fn test_abbreviate_prefix_single_long_word() {
+        assert_eq!(abbreviate_prefix("superlongname"), "sup");
+    }
+
+    #[test]
+    fn test_abbreviate_prefix_empty_segments_ignored() {
+        // Leading/trailing/double hyphens produce empty segments
+        assert_eq!(abbreviate_prefix("acme--widgets"), "aw");
+        assert_eq!(abbreviate_prefix("-acme-widgets"), "aw");
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,9 +16,9 @@ pub mod time;
 
 pub use hash::{ContentHashable, content_hash, content_hash_from_parts};
 pub use id::{
-    IdConfig, IdGenerator, IdResolver, MatchType, ParsedId, ResolvedId, ResolverConfig, child_id,
-    find_matching_ids, generate_id, id_depth, is_child_id, is_valid_id_format, normalize_id,
-    parse_id, resolve_id, validate_prefix,
+    IdConfig, IdGenerator, IdResolver, MatchType, ParsedId, ResolvedId, ResolverConfig,
+    abbreviate_prefix, child_id, find_matching_ids, generate_id, id_depth, is_child_id,
+    is_valid_id_format, normalize_id, parse_id, resolve_id, validate_prefix,
 };
 
 use std::env;


### PR DESCRIPTION
## Summary
- When no explicit `issue_prefix` config is set, the prefix is derived from the parent directory name
- Long names like `acme-widgets` produce unwieldy IDs like `acme-widgets-abc`
- Add `abbreviate_prefix()` that shortens names > 6 chars by taking the first letter of each hyphen-separated word:
  - `acme-widgets` → `aw`
  - `my-cool-project` → `mcp`
  - `superlongname` → `sup` (single word: first 3 chars)
  - `myrepo` → `myrepo` (≤6 chars: unchanged)
- Applied only in `resolve_bootstrap_issue_prefix()` directory-name fallback — explicit config overrides are unaffected
- The existing `issue_prefix` / `issue-prefix` config key (via `.beads/config.yaml`, env var `BD_ISSUE_PREFIX`, or CLI) takes priority

## Test plan
- 4 unit tests for `abbreviate_prefix()` (short unchanged, multi-word, single long word, empty segments)
- 2 integration tests for `resolve_bootstrap_issue_prefix()` (long dir name abbreviated, short dir name unchanged)