### PR TITLE
Defensive open-child guard for dot-notation children without explicit parent-child deps

### DIFF
--- a/src/cli/commands/close.rs
+++ b/src/cli/commands/close.rs
@@ -607,6 +607,25 @@ fn execute_route(
             continue;
         }
 
+        // Dot-notation child guard (fork-specific; supplements upstream's
+        // epic_counts check, which only sees formally declared parent-child deps).
+        if !args.force {
+            let open_children = storage_ctx.storage.get_open_child_ids(id)?;
+            if !open_children.is_empty() {
+                let reason = format!(
+                    "has {} open child issue(s): {}",
+                    open_children.len(),
+                    open_children.join(", ")
+                );
+                tracing::info!(id = %id, %reason, "Skipping close — open children");
+                skipped_issues.push(SkippedIssue {
+                    id: id.clone(),
+                    reason,
+                });
+                continue;
+            }
+        }
+
         let now = Utc::now();
         let close_reason = args.reason.clone().unwrap_or_else(|| "done".to_string());
         let update = IssueUpdate {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -5059,14 +5059,25 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if a database query fails.
-    /// Returns IDs of direct children (parent-child deps) that are still open/in-progress.
+    /// Returns IDs of direct children that are still open/in-progress.
+    ///
+    /// Checks both explicit parent-child dependencies AND dot-notation
+    /// convention (e.g. `epic.1`, `epic.2` are children of `epic`).
     pub fn get_open_child_ids(&self, parent_id: &str) -> Result<Vec<String>> {
+        let prefix = format!("{}.", parent_id);
         let rows = self.conn.query_with_params(
-            "SELECT d.issue_id FROM dependencies d \
-             JOIN issues i ON i.id = d.issue_id \
-             WHERE d.depends_on_id = ? AND d.type = 'parent-child' \
-             AND i.status IN ('open', 'in_progress')",
-            &[SqliteValue::from(parent_id)],
+            "SELECT i.id FROM issues i \
+             WHERE i.status IN ('open', 'in_progress') \
+             AND (i.id IN ( \
+                 SELECT d.issue_id FROM dependencies d \
+                 WHERE d.depends_on_id = ? AND d.type = 'parent-child' \
+             ) OR (i.id LIKE ? AND i.id NOT LIKE ?))",
+            &[
+                SqliteValue::from(parent_id),
+                SqliteValue::from(format!("{prefix}%").as_str()),
+                // Exclude grandchildren (e.g. epic.1.1)
+                SqliteValue::from(format!("{prefix}%.%").as_str()),
+            ],
         )?;
         let mut result = Vec::new();
         for row in &rows {

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -5059,6 +5059,24 @@ impl SqliteStorage {
     /// # Errors
     ///
     /// Returns an error if a database query fails.
+    /// Returns IDs of direct children (parent-child deps) that are still open/in-progress.
+    pub fn get_open_child_ids(&self, parent_id: &str) -> Result<Vec<String>> {
+        let rows = self.conn.query_with_params(
+            "SELECT d.issue_id FROM dependencies d \
+             JOIN issues i ON i.id = d.issue_id \
+             WHERE d.depends_on_id = ? AND d.type = 'parent-child' \
+             AND i.status IN ('open', 'in_progress')",
+            &[SqliteValue::from(parent_id)],
+        )?;
+        let mut result = Vec::new();
+        for row in &rows {
+            if let Some(id) = row.get(0).and_then(SqliteValue::as_text) {
+                result.push(id.to_string());
+            }
+        }
+        Ok(result)
+    }
+
     fn collect_descendant_ids(&self, parent_id: &str) -> Result<Vec<String>> {
         let mut result = Vec::new();
         // Use a HashSet for O(1) visited-set lookups instead of the


### PR DESCRIPTION
## Motivation

The existing `epic_counts`-based open-child guard in `close.rs` (introduced recently) catches children linked via explicit `parent-child` dependency rows. That covers the happy path — `br create --parent <epic>` always writes a dep row.

However, dot-notation child IDs (`epic.1`, `epic.2`) can exist in the `issues` table **without** a matching dep row in practice:

1. **Migrations from older tooling** (e.g., legacy `bd` Python beads DBs where parent-child relationships were ID-implicit, not dep-explicit).
2. **Bulk JSONL imports** where the source didn't emit dep rows for dot-notation siblings.
3. **Manual JSONL edits** that create dot-notation IDs without the matching dep.

In all three cases, `br close <epic>` silently closes the parent while open children remain, orphaning work items.

## Approach

Adds a small, focused `get_open_child_ids(parent_id)` helper on `SqliteStorage` that checks **both** conditions:

- explicit `parent-child` deps (same as `epic_counts`), and
- dot-notation `{parent}.{n}` ID matches where the child is still `open`/`in_progress` (excluding grandchildren).

Wires it into the `close` command as a supplementary guard after the existing `epic_counts` check. On hit, the close is skipped with `has N open child issue(s): …` — consistent with upstream's existing skipped-reason format.

## Diff shape

- `src/storage/sqlite.rs`: +29 (new `get_open_child_ids` method)
- `src/cli/commands/close.rs`: +19 (guard block after the existing `epic_counts` guard)

## Alternatives considered

1. **Extend `get_epic_counts` via a UNION** — bulk-load dot-notation implicit children into the same HashMap. More efficient for large batch closes, but harder to express cleanly in SQL without double-counting when both paths exist.
2. **Do nothing** — fine for the happy path; leaves migrated/imported corpora exposed.

Happy to refactor toward option 1 if you'd prefer bulk semantics — the per-issue approach was originally written downstream before `epic_counts` existed upstream, so the shape is historical.

## Context

Originally two commits in a downstream fork (`thunter009/beads_rust`), rebased clean onto current `main`. Related to (and orthogonal from) #256 which was the `br update` diff-leak fix.

## Testing

Builds clean (`cargo check`) on current `main`. No new test — happy to add one if useful; flag me to the style you prefer (e2e via JSONL fixture, or a unit test against `SqliteStorage` directly).