### PR TITLE
Fix import upsert parent preservation and zero-row probes

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -7565,7 +7565,8 @@ impl SqliteStorage {
     ///
     /// Updates existing rows in place, falling back to INSERT for new rows.
     /// Avoid `DELETE` + `INSERT` here: child tables reference `issues.id`, so
-    /// deleting first can orphan import-time events, labels, deps, and comments.
+    /// deleting first can cascade-drop import-time events, labels, deps, and
+    /// comments that should remain attached to the issue.
     /// This does NOT trigger dirty tracking or events.
     ///
     /// # Errors
@@ -7647,7 +7648,16 @@ impl SqliteStorage {
             ]
         };
 
-        if Self::get_issue_from_conn(&self.conn, &issue.id)?.is_some() {
+        let issue_exists = match self.conn.query_row_with_params(
+            "SELECT 1 FROM issues WHERE id = ? LIMIT 1",
+            &[SqliteValue::from(issue.id.as_str())],
+        ) {
+            Ok(_) => true,
+            Err(FrankenError::QueryReturnedNoRows) => false,
+            Err(error) => return Err(error.into()),
+        };
+
+        if issue_exists {
             let mut params = import_field_values();
             params.push(SqliteValue::from(issue.id.as_str()));
             let rows = self.conn.execute_with_params(
@@ -10902,8 +10912,46 @@ mod tests {
             !storage
                 .has_missing_issue_reference("events", "issue_id")
                 .unwrap(),
-            "import update must not orphan event rows"
+            "import update must not leave dangling event rows"
         );
+    }
+
+    #[test]
+    fn test_upsert_issue_for_import_overwrites_malformed_existing_row() {
+        let mut storage = SqliteStorage::open_memory().unwrap();
+        let stamp = Utc.with_ymd_and_hms(2026, 4, 25, 12, 0, 0).unwrap();
+        let issue = make_issue(
+            "bd-import-heals-existing",
+            "Original import title",
+            Status::Open,
+            2,
+            None,
+            stamp,
+            None,
+        );
+        storage.create_issue(&issue, "tester").unwrap();
+        storage
+            .conn
+            .execute_with_params(
+                "UPDATE issues SET status = ? WHERE id = ?",
+                &[
+                    SqliteValue::from("not-a-valid-status"),
+                    SqliteValue::from(issue.id.as_str()),
+                ],
+            )
+            .unwrap();
+
+        let mut imported = issue.clone();
+        imported.title = "Healed import title".to_string();
+        imported.updated_at = stamp + chrono::Duration::minutes(1);
+
+        storage
+            .upsert_issue_for_import(&imported)
+            .expect("import upsert should not parse the malformed row before overwriting it");
+
+        let updated = storage.get_issue(&issue.id).unwrap().unwrap();
+        assert_eq!(updated.title, "Healed import title");
+        assert_eq!(updated.status, Status::Open);
     }
 
     #[test]

--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -6617,6 +6617,17 @@ fn finish_issue_mutation_write_probe(
     rollback_result: std::result::Result<usize, FrankenError>,
 ) -> Result<()> {
     match (probe_result, rollback_result) {
+        (Ok(0), rollback) => {
+            if let Err(rollback_err) = rollback {
+                tracing::warn!(
+                    error = %rollback_err,
+                    "ROLLBACK failed after zero-row issue write probe"
+                );
+            }
+            Err(BeadsError::Database(FrankenError::Internal(
+                "write probe did not find issue inside mutation transaction".to_string(),
+            )))
+        }
         (Ok(_), Ok(_)) => Ok(()),
         (Ok(_), Err(rollback_err)) => Err(BeadsError::Database(rollback_err)),
         (Err(probe_err), Ok(_)) => Err(BeadsError::Database(probe_err)),
@@ -7552,8 +7563,9 @@ impl SqliteStorage {
 
     /// Upsert an issue (create or update) for import operations.
     ///
-    /// Uses explicit DELETE + INSERT to handle both cases (fsqlite does not
-    /// reliably support INSERT OR REPLACE).
+    /// Updates existing rows in place, falling back to INSERT for new rows.
+    /// Avoid `DELETE` + `INSERT` here: child tables reference `issues.id`, so
+    /// deleting first can orphan import-time events, labels, deps, and comments.
     /// This does NOT trigger dirty tracking or events.
     ///
     /// # Errors
@@ -7571,13 +7583,99 @@ impl SqliteStorage {
         let deleted_at_str = issue.deleted_at.map(|dt| dt.to_rfc3339());
         let compacted_at_str = issue.compacted_at.map(|dt| dt.to_rfc3339());
 
-        // Explicit DELETE + INSERT instead of INSERT OR REPLACE because
-        // fsqlite does not enforce UNIQUE constraints on non-rowid columns.
-        self.conn.execute_with_params(
-            "DELETE FROM issues WHERE id = ?",
-            &[SqliteValue::from(issue.id.as_str())],
-        )?;
+        let import_field_values = || {
+            vec![
+                issue
+                    .content_hash
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(issue.title.as_str()),
+                SqliteValue::from(issue.description.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.design.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.acceptance_criteria.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.notes.as_deref().unwrap_or("")),
+                SqliteValue::from(status_str),
+                SqliteValue::from(i64::from(issue.priority.0)),
+                SqliteValue::from(issue_type_str),
+                issue
+                    .assignee
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(issue.owner.as_deref().unwrap_or("")),
+                issue
+                    .estimated_minutes
+                    .map_or(SqliteValue::Null, |v| SqliteValue::from(i64::from(v))),
+                SqliteValue::from(created_at_str.as_str()),
+                SqliteValue::from(issue.created_by.as_deref().unwrap_or("")),
+                SqliteValue::from(updated_at_str.as_str()),
+                closed_at_str
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(issue.close_reason.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.closed_by_session.as_deref().unwrap_or("")),
+                due_at_str
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                defer_until_str
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                issue
+                    .external_ref
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(issue.source_system.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.source_repo.as_deref().unwrap_or(".")),
+                deleted_at_str
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(issue.deleted_by.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.delete_reason.as_deref().unwrap_or("")),
+                SqliteValue::from(issue.original_type.as_deref().unwrap_or("")),
+                SqliteValue::from(i64::from(issue.compaction_level.unwrap_or(0))),
+                compacted_at_str
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                issue
+                    .compacted_at_commit
+                    .as_deref()
+                    .map_or(SqliteValue::Null, SqliteValue::from),
+                SqliteValue::from(i64::from(issue.original_size.unwrap_or(0))),
+                SqliteValue::from(issue.sender.as_deref().unwrap_or("")),
+                SqliteValue::from(i64::from(i32::from(issue.ephemeral))),
+                SqliteValue::from(i64::from(i32::from(issue.pinned))),
+                SqliteValue::from(i64::from(i32::from(issue.is_template))),
+            ]
+        };
 
+        if Self::get_issue_from_conn(&self.conn, &issue.id)?.is_some() {
+            let mut params = import_field_values();
+            params.push(SqliteValue::from(issue.id.as_str()));
+            let rows = self.conn.execute_with_params(
+                r"UPDATE issues SET
+                    content_hash = ?, title = ?, description = ?, design = ?,
+                    acceptance_criteria = ?, notes = ?, status = ?, priority = ?,
+                    issue_type = ?, assignee = ?, owner = ?, estimated_minutes = ?,
+                    created_at = ?, created_by = ?, updated_at = ?, closed_at = ?,
+                    close_reason = ?, closed_by_session = ?, due_at = ?, defer_until = ?,
+                    external_ref = ?, source_system = ?, source_repo = ?, deleted_at = ?,
+                    deleted_by = ?, delete_reason = ?, original_type = ?, compaction_level = ?,
+                    compacted_at = ?, compacted_at_commit = ?, original_size = ?, sender = ?,
+                    ephemeral = ?, pinned = ?, is_template = ?
+                  WHERE id = ?",
+                &params,
+            )?;
+            if rows == 0 {
+                return Err(BeadsError::Database(FrankenError::Internal(format!(
+                    "import update did not find existing issue {}",
+                    issue.id
+                ))));
+            }
+            return Ok(true);
+        }
+
+        let mut insert_params = Vec::with_capacity(36);
+        insert_params.push(SqliteValue::from(issue.id.as_str()));
+        insert_params.extend(import_field_values());
         let rows = self.conn.execute_with_params(
             r"INSERT INTO issues (
                 id, content_hash, title, description, design, acceptance_criteria, notes,
@@ -7590,44 +7688,7 @@ impl SqliteStorage {
             ) VALUES (
                 ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
             )",
-            &[
-                SqliteValue::from(issue.id.as_str()),
-                issue.content_hash.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(issue.title.as_str()),
-                SqliteValue::from(issue.description.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.design.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.acceptance_criteria.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.notes.as_deref().unwrap_or("")),
-                SqliteValue::from(status_str),
-                SqliteValue::from(i64::from(issue.priority.0)),
-                SqliteValue::from(issue_type_str),
-                issue.assignee.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(issue.owner.as_deref().unwrap_or("")),
-                issue.estimated_minutes.map_or(SqliteValue::Null, |v| SqliteValue::from(i64::from(v))),
-                SqliteValue::from(created_at_str.as_str()),
-                SqliteValue::from(issue.created_by.as_deref().unwrap_or("")),
-                SqliteValue::from(updated_at_str.as_str()),
-                closed_at_str.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(issue.close_reason.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.closed_by_session.as_deref().unwrap_or("")),
-                due_at_str.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                defer_until_str.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                issue.external_ref.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(issue.source_system.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.source_repo.as_deref().unwrap_or(".")),
-                deleted_at_str.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(issue.deleted_by.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.delete_reason.as_deref().unwrap_or("")),
-                SqliteValue::from(issue.original_type.as_deref().unwrap_or("")),
-                SqliteValue::from(i64::from(issue.compaction_level.unwrap_or(0))),
-                compacted_at_str.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                issue.compacted_at_commit.as_deref().map_or(SqliteValue::Null, SqliteValue::from),
-                SqliteValue::from(i64::from(issue.original_size.unwrap_or(0))),
-                SqliteValue::from(issue.sender.as_deref().unwrap_or("")),
-                SqliteValue::from(i64::from(i32::from(issue.ephemeral))),
-                SqliteValue::from(i64::from(i32::from(issue.pinned))),
-                SqliteValue::from(i64::from(i32::from(issue.is_template))),
-            ],
+            &insert_params,
         )?;
 
         Ok(rows > 0)
@@ -10803,6 +10864,49 @@ mod tests {
     }
 
     #[test]
+    fn test_upsert_issue_for_import_updates_existing_issue_without_deleting_parent_row() {
+        let mut storage = SqliteStorage::open_memory().unwrap();
+        let stamp = Utc.with_ymd_and_hms(2026, 4, 25, 12, 0, 0).unwrap();
+        let issue = make_issue(
+            "bd-import-update-existing",
+            "Original import title",
+            Status::Open,
+            2,
+            None,
+            stamp,
+            None,
+        );
+        storage.create_issue(&issue, "tester").unwrap();
+        let events_before = storage.get_events(&issue.id, 20).unwrap();
+        assert!(
+            !events_before.is_empty(),
+            "created issue should have event rows that reference the parent issue"
+        );
+
+        let mut imported = issue.clone();
+        imported.title = "Updated import title".to_string();
+        imported.updated_at = stamp + chrono::Duration::minutes(1);
+
+        storage
+            .upsert_issue_for_import(&imported)
+            .expect("import update should not delete the parent row first");
+
+        let updated = storage.get_issue(&issue.id).unwrap().unwrap();
+        assert_eq!(updated.title, "Updated import title");
+        assert_eq!(
+            storage.get_events(&issue.id, 20).unwrap().len(),
+            events_before.len(),
+            "import update should preserve existing child rows instead of deleting and reinserting the parent"
+        );
+        assert!(
+            !storage
+                .has_missing_issue_reference("events", "issue_id")
+                .unwrap(),
+            "import update must not orphan event rows"
+        );
+    }
+
+    #[test]
     fn test_pragmas_are_set_correctly() {
         let storage = SqliteStorage::open_memory().unwrap();
 
@@ -12570,6 +12674,45 @@ mod tests {
         let err = result.expect_err("write failure should surface");
         assert!(
             err.to_string().contains("write failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_finish_issue_mutation_write_probe_rejects_zero_row_update() {
+        let result = finish_issue_mutation_write_probe(Ok(0), Ok(0));
+
+        let err =
+            result.expect_err("zero-row probe update should indicate write-path invisibility");
+        assert!(
+            err.to_string().contains("write probe did not find issue"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_finish_issue_mutation_write_probe_prefers_zero_row_over_rollback_error() {
+        let result = finish_issue_mutation_write_probe(
+            Ok(0),
+            Err(FrankenError::Internal("rollback failed".to_string())),
+        );
+
+        let err = result.expect_err("zero-row probe update should remain the primary failure");
+        assert!(
+            err.to_string().contains("write probe did not find issue"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_probe_issue_mutation_write_path_rejects_missing_issue() {
+        let storage = SqliteStorage::open_memory().unwrap();
+
+        let err = storage
+            .probe_issue_mutation_write_path("bd-missing-probe")
+            .expect_err("missing issue must not pass a mutation write-path probe");
+        assert!(
+            err.to_string().contains("write probe did not find issue"),
             "unexpected error: {err}"
         );
     }


### PR DESCRIPTION
## Summary

Reference implementation for #263.

This patch fixes two storage correctness edge cases:

- Update existing imported issues in place instead of deleting and reinserting the parent `issues` row.
- Treat zero-row mutation write probes as failures instead of successful probes.

I am keeping this as a draft/reference PR because the issue is the primary report. If you prefer to reimplement or cherry-pick instead of merging foreign code directly, the patch is intentionally small and isolated to `src/storage/sqlite.rs`.

## Details

`upsert_issue_for_import()` previously used explicit `DELETE` + `INSERT` for existing issues. Because child tables reference `issues(id)` with cascading foreign keys, that can drop child history such as events/comments/deps/labels that should remain attached to the issue. The patch now checks whether the issue exists, runs an in-place `UPDATE` for existing rows, and keeps the existing `INSERT` path for new rows.

The existence check is intentionally a narrow `SELECT 1`, not `get_issue_from_conn()`: import should not have to parse the current row before overwriting it from valid JSONL. A regression test covers a malformed existing row being healed by import upsert.

`finish_issue_mutation_write_probe()` previously treated `Ok(0)` as success. The patch returns an error when the probe update matches zero rows, and preserves that zero-row diagnostic even if rollback also fails.

## Tests

Added regressions for:

- import upsert preserving existing child rows and avoiding missing issue references
- import upsert overwriting a malformed existing row without parsing it first
- zero-row write probes returning an error
- zero-row probe errors taking precedence over rollback failure
- missing issue write-path probes failing instead of succeeding

Validation run on this branch:

- `cargo fmt --check`
- `ubs --files src/storage/sqlite.rs --only=rust --format=json --ci` — 0 critical findings
- `CARGO_BUILD_JOBS=2 cargo check --all-targets`
- `CARGO_BUILD_JOBS=2 cargo clippy --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test --lib` — `1418 passed; 0 failed`
- `CARGO_BUILD_JOBS=2 cargo test --release e2e_sync` — sync-filtered release tests passed (`39 passed; 0 failed`)
