### PR TITLE
feat(list): effective-priority view via dependency-chain inheritance

### DIFF
--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1189,4 +1189,210 @@ mod tests {
             BeadsError::InvalidPriority { ref priority } if priority == "7"
         ));
     }
+
+    fn issue(id: &str, priority: Priority) -> Issue {
+        Issue {
+            id: id.to_string(),
+            priority,
+            status: Status::Open,
+            ..Default::default()
+        }
+    }
+
+    fn closed_issue(id: &str, priority: Priority) -> Issue {
+        Issue {
+            id: id.to_string(),
+            priority,
+            status: Status::Closed,
+            ..Default::default()
+        }
+    }
+
+    fn edge(dependent: &str, blocker: &str) -> (String, String) {
+        (dependent.to_string(), blocker.to_string())
+    }
+
+    #[test]
+    fn test_effective_priority_simple_chain_promotes_low_to_high() {
+        // P3 leaf blocks a P1 task → leaf is effectively P1
+        let issues = vec![
+            issue("a", Priority::HIGH),
+            issue("b", Priority::LOW),
+        ];
+        let edges = vec![edge("a", "b")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["b"].priority, Priority::HIGH);
+        assert!(result["b"].is_promoted());
+        assert_eq!(result["b"].promoted_from, Some(Priority::LOW));
+        assert_eq!(result["b"].promoted_by, vec!["a"]);
+        // High-priority task: not promoted (already at target)
+        assert_eq!(result["a"].priority, Priority::HIGH);
+        assert!(!result["a"].is_promoted());
+    }
+
+    #[test]
+    fn test_effective_priority_takes_min_across_branching() {
+        // P3 blocks both a P0 and a P2 → P3 effective P0 (most urgent)
+        let issues = vec![
+            issue("crit", Priority::CRITICAL),
+            issue("med", Priority::MEDIUM),
+            issue("leaf", Priority::LOW),
+        ];
+        let edges = vec![edge("crit", "leaf"), edge("med", "leaf")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["leaf"].priority, Priority::CRITICAL);
+        assert!(result["leaf"].is_promoted());
+        assert_eq!(result["leaf"].promoted_by, vec!["crit"]);
+    }
+
+    #[test]
+    fn test_effective_priority_propagates_through_chain() {
+        // a (P0) <- b (P3) <- c (P2): c blocks b, b blocks a
+        // c is effectively P0 via the b → a chain.
+        let issues = vec![
+            issue("a", Priority::CRITICAL),
+            issue("b", Priority::LOW),
+            issue("c", Priority::MEDIUM),
+        ];
+        let edges = vec![edge("a", "b"), edge("b", "c")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["b"].priority, Priority::CRITICAL);
+        assert_eq!(result["c"].priority, Priority::CRITICAL);
+        assert!(result["c"].is_promoted());
+    }
+
+    #[test]
+    fn test_effective_priority_no_promotion_when_self_already_more_urgent() {
+        // P0 blocks a P3 → P0 stays P0 (not demoted)
+        let issues = vec![
+            issue("crit", Priority::CRITICAL),
+            issue("low", Priority::LOW),
+        ];
+        let edges = vec![edge("low", "crit")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["crit"].priority, Priority::CRITICAL);
+        assert!(!result["crit"].is_promoted());
+    }
+
+    #[test]
+    fn test_effective_priority_closed_dependent_does_not_promote() {
+        // A closed P0 should NOT promote a P3 blocker — closed work blocks nothing.
+        let issues = vec![
+            closed_issue("done", Priority::CRITICAL),
+            issue("leaf", Priority::LOW),
+        ];
+        let edges = vec![edge("done", "leaf")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["leaf"].priority, Priority::LOW);
+        assert!(!result["leaf"].is_promoted());
+    }
+
+    #[test]
+    fn test_effective_priority_external_deps_are_skipped() {
+        // external:* edges must not promote — v1 doesn't resolve external workspaces.
+        let issues = vec![issue("local", Priority::LOW)];
+        let edges = vec![
+            edge("external:foo-1", "local"),
+            edge("local", "external:bar-7"),
+        ];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["local"].priority, Priority::LOW);
+        assert!(!result["local"].is_promoted());
+    }
+
+    #[test]
+    fn test_effective_priority_handles_cycle_without_panicking() {
+        // a depends on b, b depends on a — pathological but possible if check_cycle
+        // is bypassed elsewhere. Walk must terminate without infinite recursion.
+        let issues = vec![
+            issue("a", Priority::HIGH),
+            issue("b", Priority::LOW),
+        ];
+        let edges = vec![edge("a", "b"), edge("b", "a")];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        // Both terminate; b promotes via a's HIGH priority.
+        assert_eq!(result["b"].priority, Priority::HIGH);
+        assert_eq!(result["a"].priority, Priority::HIGH);
+    }
+
+    #[test]
+    fn test_effective_priority_unrelated_issues_keep_static_priority() {
+        // Issues with no edges between them — each keeps its static priority.
+        let issues = vec![
+            issue("a", Priority::HIGH),
+            issue("b", Priority::LOW),
+            issue("c", Priority::MEDIUM),
+        ];
+        let edges = vec![];
+
+        let result = compute_effective_priorities(&issues, &edges);
+
+        assert_eq!(result["a"].priority, Priority::HIGH);
+        assert_eq!(result["b"].priority, Priority::LOW);
+        assert_eq!(result["c"].priority, Priority::MEDIUM);
+        for entry in result.values() {
+            assert!(!entry.is_promoted());
+        }
+    }
+
+    #[test]
+    fn test_sort_by_effective_priority_orders_promoted_first() {
+        let mut issues = vec![
+            issue("low_leaf", Priority::LOW),
+            issue("high_root", Priority::HIGH),
+            issue("plain_med", Priority::MEDIUM),
+        ];
+        let mut effective_priorities = HashMap::new();
+        // low_leaf is promoted to HIGH because it blocks high_root
+        effective_priorities.insert(
+            "low_leaf".to_string(),
+            EffectivePriority {
+                priority: Priority::HIGH,
+                promoted_from: Some(Priority::LOW),
+                promoted_by: vec!["high_root".to_string()],
+            },
+        );
+        effective_priorities.insert(
+            "high_root".to_string(),
+            EffectivePriority::new(Priority::HIGH),
+        );
+        effective_priorities.insert(
+            "plain_med".to_string(),
+            EffectivePriority::new(Priority::MEDIUM),
+        );
+
+        sort_by_effective_priority(&mut issues, &effective_priorities, false);
+
+        // Both HIGH-effective issues come before MEDIUM, and the LOW-statically-but-
+        // promoted-to-HIGH issue is intermixed with the HIGH static issue — order
+        // within a tier is created_at then id (deterministic).
+        let ids: Vec<&str> = issues.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids[2], "plain_med", "MEDIUM should sort last");
+        assert!(
+            (ids[0] == "low_leaf" && ids[1] == "high_root")
+                || (ids[0] == "high_root" && ids[1] == "low_leaf"),
+            "promoted LOW should be tied with static HIGH at the top, got {ids:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_sort_key_accepts_effective() {
+        assert!(validate_sort_key(Some("effective")).is_ok());
+        assert!(validate_sort_key(Some("priority")).is_ok());
+        assert!(validate_sort_key(Some("nonsense")).is_err());
+    }
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -11,8 +11,9 @@ use crate::config;
 use crate::error::{BeadsError, Result};
 use crate::format::csv;
 use crate::format::{
-    IssueWithCounts, ListPage, TextFormatOptions, format_issue_line_with, format_issue_long_with,
-    format_issue_pretty_with, terminal_width,
+    EffectivePriority, IssueWithCounts, ListPage, TextFormatOptions, format_issue_line_with,
+    format_issue_line_with_effective, format_issue_long_with, format_issue_pretty_with,
+    terminal_width,
 };
 use crate::model::{IssueType, Priority, Status};
 use crate::output::{IssueTable, IssueTableColumns, JsonArrayPageMeta, OutputContext, OutputMode};
@@ -69,7 +70,8 @@ fn execute_inner(
 
     // Build filter from args
     let mut filters = build_filters(args)?;
-    let client_filters = needs_client_filters(args);
+    let effective_sort = args.sort.as_deref() == Some("effective");
+    let client_filters = needs_client_filters(args) || effective_sort;
 
     // Determine output format early so we know whether to run a count query.
     let output_format = resolve_output_format_with_outer_mode(
@@ -150,6 +152,21 @@ fn execute_inner(
     };
     if client_filters {
         issues = apply_client_filters(issues, args)?;
+    }
+
+    let effective_priorities = if args.effective_priority || effective_sort {
+        Some(compute_effective_priorities(
+            &issues,
+            &storage.get_blocks_dep_edges()?,
+        ))
+    } else {
+        None
+    };
+
+    if effective_sort {
+        if let Some(ref priorities) = effective_priorities {
+            sort_by_effective_priority(&mut issues, priorities, args.reverse);
+        }
     }
 
     // For JSON output, determine the total matching count.
@@ -278,6 +295,7 @@ fn execute_inner(
                     IssueTableColumns {
                         id: true,
                         priority: true,
+                        effective_priority: args.effective_priority,
                         status: true,
                         issue_type: true,
                         title: true,
@@ -290,6 +308,7 @@ fn execute_inner(
                     IssueTableColumns {
                         id: true,
                         priority: true,
+                        effective_priority: args.effective_priority,
                         status: true,
                         issue_type: true,
                         title: true,
@@ -298,6 +317,7 @@ fn execute_inner(
                 };
                 let mut table = IssueTable::new(&issues, ctx.theme())
                     .columns(columns)
+                    .effective_priorities(effective_priorities.clone().unwrap_or_default())
                     .title(format!("Issues ({})", issues.len()))
                     .wrap(args.wrap);
                 if args.wrap {
@@ -310,7 +330,17 @@ fn execute_inner(
             } else {
                 // Note: bd outputs nothing when no issues found, matching that for conformance
                 for issue in &issues {
-                    let line = format_issue_line_with(issue, format_options);
+                    let line = if args.effective_priority {
+                        format_issue_line_with_effective(
+                            issue,
+                            format_options,
+                            effective_priorities
+                                .as_ref()
+                                .and_then(|priorities| priorities.get(&issue.id)),
+                        )
+                    } else {
+                        format_issue_line_with(issue, format_options)
+                    };
                     println!("{line}");
                 }
             }
@@ -498,7 +528,11 @@ fn build_filters(args: &ListArgs) -> Result<ListFilters> {
         title_contains: args.title_contains.clone(),
         limit: Some(args.limit.unwrap_or(DEFAULT_LIST_LIMIT)),
         offset: Some(args.offset.unwrap_or(DEFAULT_LIST_OFFSET)),
-        sort: args.sort.clone(),
+        sort: if args.sort.as_deref() == Some("effective") {
+            None
+        } else {
+            args.sort.clone()
+        },
         reverse: args.reverse,
         labels: if args.label.is_empty() {
             None
@@ -531,6 +565,141 @@ fn needs_client_filters(args: &ListArgs) -> bool {
         || args.notes_contains.is_some()
         || args.deferred
         || args.overdue
+}
+
+fn compute_effective_priorities(
+    issues: &[crate::model::Issue],
+    edges: &[(String, String)],
+) -> HashMap<String, EffectivePriority> {
+    let issue_by_id: HashMap<&str, &crate::model::Issue> = issues
+        .iter()
+        .map(|issue| (issue.id.as_str(), issue))
+        .collect();
+    let visible_ids: HashSet<&str> = issue_by_id.keys().copied().collect();
+    let active_ids: HashSet<&str> = issues
+        .iter()
+        .filter(|issue| !issue.status.is_terminal())
+        .map(|issue| issue.id.as_str())
+        .collect();
+    let mut dependents_by_blocker: HashMap<&str, Vec<&str>> = HashMap::new();
+
+    for (issue_id, depends_on_id) in edges {
+        let dependent_id = issue_id.as_str();
+        let blocker_id = depends_on_id.as_str();
+        if issue_id.starts_with("external:") || depends_on_id.starts_with("external:") {
+            continue;
+        }
+        if active_ids.contains(dependent_id) && visible_ids.contains(blocker_id) {
+            dependents_by_blocker
+                .entry(blocker_id)
+                .or_default()
+                .push(dependent_id);
+        }
+    }
+
+    let mut memo = HashMap::new();
+    let mut visiting = HashSet::new();
+    for issue in issues {
+        let _ = effective_priority_for(
+            issue.id.as_str(),
+            &issue_by_id,
+            &dependents_by_blocker,
+            &mut memo,
+            &mut visiting,
+        );
+    }
+    memo
+}
+
+fn effective_priority_for(
+    id: &str,
+    issue_by_id: &HashMap<&str, &crate::model::Issue>,
+    dependents_by_blocker: &HashMap<&str, Vec<&str>>,
+    memo: &mut HashMap<String, EffectivePriority>,
+    visiting: &mut HashSet<String>,
+) -> EffectivePriority {
+    if let Some(cached) = memo.get(id) {
+        return cached.clone();
+    }
+
+    let Some(issue) = issue_by_id.get(id).copied() else {
+        return EffectivePriority::new(Priority::MEDIUM);
+    };
+    if issue.status.is_terminal() {
+        let effective = EffectivePriority::new(issue.priority);
+        memo.insert(id.to_string(), effective.clone());
+        return effective;
+    }
+
+    if !visiting.insert(id.to_string()) {
+        return EffectivePriority::new(issue.priority);
+    }
+
+    let mut effective = issue.priority;
+    let mut promoted_by = Vec::new();
+    if let Some(dependents) = dependents_by_blocker.get(id) {
+        for dependent_id in dependents {
+            if *dependent_id == id {
+                continue;
+            }
+            let dependent_effective = effective_priority_for(
+                dependent_id,
+                issue_by_id,
+                dependents_by_blocker,
+                memo,
+                visiting,
+            );
+            if dependent_effective.priority.0 < effective.0 {
+                effective = dependent_effective.priority;
+                promoted_by.clear();
+                promoted_by.push((*dependent_id).to_string());
+            } else if dependent_effective.priority.0 == effective.0
+                && effective.0 < issue.priority.0
+            {
+                promoted_by.push((*dependent_id).to_string());
+            }
+        }
+    }
+
+    visiting.remove(id);
+    promoted_by.sort();
+    promoted_by.dedup();
+    let effective_priority = if effective.0 < issue.priority.0 {
+        EffectivePriority {
+            priority: effective,
+            promoted_from: Some(issue.priority),
+            promoted_by,
+        }
+    } else {
+        EffectivePriority::new(issue.priority)
+    };
+    memo.insert(id.to_string(), effective_priority.clone());
+    effective_priority
+}
+
+fn sort_by_effective_priority(
+    issues: &mut [crate::model::Issue],
+    effective_priorities: &HashMap<String, EffectivePriority>,
+    reverse: bool,
+) {
+    issues.sort_by(|a, b| {
+        let a_priority = effective_priorities
+            .get(&a.id)
+            .map_or(a.priority.0, |priority| priority.priority.0);
+        let b_priority = effective_priorities
+            .get(&b.id)
+            .map_or(b.priority.0, |priority| priority.priority.0);
+        let ordering = if reverse {
+            b_priority
+                .cmp(&a_priority)
+                .then_with(|| a.created_at.cmp(&b.created_at))
+        } else {
+            a_priority
+                .cmp(&b_priority)
+                .then_with(|| b.created_at.cmp(&a.created_at))
+        };
+        ordering.then_with(|| a.id.cmp(&b.id))
+    });
 }
 
 fn should_use_full_relation_scan(
@@ -690,7 +859,8 @@ fn validate_sort_key(sort: Option<&str>) -> Result<()> {
     };
 
     match sort_key {
-        "priority" | "created_at" | "updated_at" | "title" | "created" | "updated" => Ok(()),
+        "priority" | "effective" | "created_at" | "updated_at" | "title" | "created"
+        | "updated" => Ok(()),
         _ => Err(BeadsError::Validation {
             field: "sort".to_string(),
             reason: format!("invalid sort field '{sort_key}'"),

--- a/src/cli/commands/orphans.rs
+++ b/src/cli/commands/orphans.rs
@@ -236,6 +236,7 @@ fn execute_inner(
             let columns = IssueTableColumns {
                 id: true,
                 priority: true,
+                effective_priority: false,
                 status: false,
                 issue_type: false,
                 title: true,

--- a/src/cli/commands/query.rs
+++ b/src/cli/commands/query.rs
@@ -141,6 +141,7 @@ impl SavedFilters {
             format: None,
             stats: false,
             fields: None,
+            effective_priority: false,
         }
     }
 
@@ -210,6 +211,7 @@ impl SavedFilters {
             format: cli.format,
             stats: cli.stats,
             fields: cli.fields.clone(),
+            effective_priority: cli.effective_priority,
         }
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -143,6 +143,7 @@ const DEP_TYPE_CANDIDATES: &[(&str, &str)] = &[
 
 const SORT_KEY_CANDIDATES: &[(&str, &str)] = &[
     ("priority", "Priority"),
+    ("effective", "Effective priority"),
     ("created_at", "Created at"),
     ("updated_at", "Updated at"),
     ("title", "Title"),
@@ -1506,9 +1507,13 @@ pub struct ListArgs {
     #[arg(long)]
     pub offset: Option<usize>,
 
-    /// Sort field (`priority`, `created_at`, `updated_at`, `title`)
+    /// Sort field (`priority`, `effective`, `created_at`, `updated_at`, `title`)
     #[arg(long, add = ArgValueCompleter::new(sort_key_completer))]
     pub sort: Option<String>,
+
+    /// Show view-time effective priority inherited from downstream dependents
+    #[arg(long)]
+    pub effective_priority: bool,
 
     /// Reverse sort order
     #[arg(long, short = 'r')]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -46,11 +46,12 @@ pub use output::{
     StatsSummary, TreeNode,
 };
 pub use text::{
-    TextFormatOptions, format_issue_line, format_issue_line_with, format_issue_long_with,
-    format_issue_pretty_with, format_priority, format_priority_badge, format_priority_label,
-    format_status_icon, format_status_icon_colored, format_status_label, format_type_badge,
-    format_type_badge_colored, format_type_label, sanitize_terminal_inline, sanitize_terminal_text,
-    terminal_width, truncate_title,
+    EffectivePriority, TextFormatOptions, format_issue_line, format_issue_line_with,
+    format_issue_line_with_effective, format_issue_long_with, format_issue_pretty_with,
+    format_priority, format_priority_badge, format_priority_label, format_status_icon,
+    format_status_icon_colored, format_status_label, format_type_badge, format_type_badge_colored,
+    format_type_label, sanitize_terminal_inline, sanitize_terminal_text, terminal_width,
+    truncate_title,
 };
 
 // Rich output support

--- a/src/format/text.rs
+++ b/src/format/text.rs
@@ -293,12 +293,54 @@ fn visible_len(text: &str) -> usize {
     UnicodeWidthStr::width(text)
 }
 
+/// View-time priority inherited from downstream dependents.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EffectivePriority {
+    pub priority: Priority,
+    pub promoted_from: Option<Priority>,
+    pub promoted_by: Vec<String>,
+}
+
+impl EffectivePriority {
+    #[must_use]
+    pub fn new(priority: Priority) -> Self {
+        Self {
+            priority,
+            promoted_from: None,
+            promoted_by: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_promoted(&self) -> bool {
+        self.promoted_from.is_some() && !self.promoted_by.is_empty()
+    }
+}
+
 /// Format a single-line issue summary with options.
 ///
 /// Format: `{icon} {id} [● {priority}] [{type}] - {title}`
 /// (matches bd text output format)
 #[must_use]
 pub fn format_issue_line_with(issue: &Issue, options: TextFormatOptions) -> String {
+    format_issue_line_inner(issue, options, None)
+}
+
+/// Format a single-line issue summary with an opt-in effective-priority marker.
+#[must_use]
+pub fn format_issue_line_with_effective(
+    issue: &Issue,
+    options: TextFormatOptions,
+    effective: Option<&EffectivePriority>,
+) -> String {
+    format_issue_line_inner(issue, options, effective)
+}
+
+fn format_issue_line_inner(
+    issue: &Issue,
+    options: TextFormatOptions,
+    effective: Option<&EffectivePriority>,
+) -> String {
     let status_icon_plain = format_status_icon(&issue.status);
     // Account for the bullet in priority badge: [● P2]
     let priority_badge_plain = format!("[● {}]", format_priority(&issue.priority));
@@ -326,12 +368,26 @@ pub fn format_issue_line_with(issue: &Issue, options: TextFormatOptions) -> Stri
 
     let status_icon = format_status_icon_colored(&issue.status, options.use_color);
     let priority_badge = format_priority_badge(&issue.priority, options.use_color);
+    let effective_marker = effective.map_or_else(String::new, format_effective_priority_marker);
     let type_badge = format_type_badge_colored(&issue.issue_type, options.use_color);
 
     format!(
-        "{status_icon} {issue_id} {priority_badge} {type_badge} - {title}",
+        "{status_icon} {issue_id} {priority_badge}{effective_marker} {type_badge} - {title}",
         issue_id = issue_id.as_ref()
     )
+}
+
+fn format_effective_priority_marker(effective: &EffectivePriority) -> String {
+    let promoted_from = effective.promoted_from.unwrap_or(effective.priority);
+    if effective.is_promoted() {
+        format!(
+            " => P{} via blocks {}",
+            effective.priority.0,
+            effective.promoted_by.join(", ")
+        )
+    } else {
+        format!(" => P{}", promoted_from.0)
+    }
 }
 
 /// Format a single-line issue summary.

--- a/src/output/components/issue_table.rs
+++ b/src/output/components/issue_table.rs
@@ -68,6 +68,7 @@ impl IssueTableColumns {
         Self {
             id: true,
             priority: true,
+            effective_priority: false,
             status: true,
             issue_type: true,
             title: true,

--- a/src/output/components/issue_table.rs
+++ b/src/output/components/issue_table.rs
@@ -1,6 +1,6 @@
 use crate::format::{
-    format_status_label, format_type_label, sanitize_terminal_inline, sanitize_terminal_text,
-    truncate_title,
+    EffectivePriority, format_status_label, format_type_label, sanitize_terminal_inline,
+    sanitize_terminal_text, truncate_title,
 };
 use crate::model::Issue;
 use crate::output::Theme;
@@ -17,6 +17,7 @@ pub struct IssueTable<'a> {
     title: Option<String>,
     highlight_query: Option<String>,
     context_snippets: Option<HashMap<String, String>>,
+    effective_priorities: HashMap<String, EffectivePriority>,
     width: Option<usize>,
     wrap: bool,
 }
@@ -26,6 +27,7 @@ pub struct IssueTable<'a> {
 pub struct IssueTableColumns {
     pub id: bool,
     pub priority: bool,
+    pub effective_priority: bool,
     pub status: bool,
     pub issue_type: bool,
     pub title: bool,
@@ -88,6 +90,7 @@ impl<'a> IssueTable<'a> {
             title: None,
             highlight_query: None,
             context_snippets: None,
+            effective_priorities: HashMap::new(),
             width: None,
             wrap: false,
         }
@@ -135,6 +138,12 @@ impl<'a> IssueTable<'a> {
     }
 
     #[must_use]
+    pub fn effective_priorities(mut self, priorities: HashMap<String, EffectivePriority>) -> Self {
+        self.effective_priorities = priorities;
+        self
+    }
+
+    #[must_use]
     #[allow(clippy::too_many_lines)]
     pub fn build(&self) -> Table {
         let highlight_regex = self
@@ -160,6 +169,13 @@ impl<'a> IssueTable<'a> {
         }
         if self.columns.priority {
             table = table.with_column(Column::new("P").justify(JustifyMethod::Center).width(3));
+        }
+        if self.columns.effective_priority {
+            table = table.with_column(
+                Column::new("Eff")
+                    .justify(JustifyMethod::Center)
+                    .min_width(3),
+            );
         }
         if self.columns.status {
             table = table.with_column(Column::new("Status").min_width(8));
@@ -204,6 +220,29 @@ impl<'a> IssueTable<'a> {
                 cells.push(
                     Cell::new(Text::new(format!("P{}", issue.priority.0)))
                         .style(self.theme.priority_style(issue.priority)),
+                );
+            }
+            if self.columns.effective_priority {
+                let effective = self.effective_priorities.get(&issue.id);
+                let label = effective.map_or_else(
+                    || format!("P{}", issue.priority.0),
+                    |priority| {
+                        if priority.is_promoted() {
+                            format!(
+                                "P{}↑ {}",
+                                priority.priority.0,
+                                priority.promoted_by.join(",")
+                            )
+                        } else {
+                            format!("P{}", priority.priority.0)
+                        }
+                    },
+                );
+                let effective_priority =
+                    effective.map_or(issue.priority, |priority| priority.priority);
+                cells.push(
+                    Cell::new(Text::new(sanitize_terminal_inline(&label).into_owned()))
+                        .style(self.theme.priority_style(effective_priority)),
                 );
             }
             if self.columns.status {


### PR DESCRIPTION
## Summary

Adds a view-time **effective-priority** computation to \`br list\`: a P3 task that blocks a P1 task is *effectively* P1 work, and this PR makes that visible without changing the data model.

Pattern: classic OS-scheduling priority inheritance (Mars Pathfinder is the canonical war story). View-time only — no schema changes, no SQL changes, no data-shape changes.

## What's added

Three opt-in surfaces:

- \`br list --effective-priority\` — shows an extra \`Eff\` column with each issue's effective priority. Promotion shows as \`P3↑ alpha,beta\` (lifted from P3 by tasks alpha and beta).
- \`br list --sort=effective\` — sorts by effective priority (most urgent first by default, \`-r\` reverses). Ordering: effective-priority ascending (P0 most urgent), then created_at desc, then id asc.
- New sort-key value \`effective\` accepted by the existing \`--sort\` flag and registered in \`SORT_KEY_CANDIDATES\` so completion picks it up.

**Default \`br list\` output is unchanged.** The new column appears only with \`--effective-priority\`; static-priority sorting is unchanged. JSON and CSV schemas are unchanged in this PR — opt-in field exposure is left for a follow-up if there's interest.

## Algorithm

\`\`\`
effective_priority(t) = min(t.priority, min(effective_priority(d) for d in tasks_that_t_blocks))
\`\`\`

Note the \`min\` — \`br\`'s priority ordering puts P0 at most-urgent, so 'most urgent' is the *minimum* numeric value, not the max. (This caught me in early notes; mentioning it in case it catches a reviewer.)

Implementation:

- One pass over \`Storage::get_blocks_dep_edges()\` (already in \`src/storage/sqlite.rs\`) to build reverse adjacency: blocker → \[dependent...\]. No new SQL queries.
- Memoized DFS over the in-memory issues list. O(V+E).
- Cycle-defensive (visiting set) — even though \`check_cycle()\` is run on insert, the walk is robust to cycles encountered any other way.

## Edge cases handled

- **Closed/tombstoned dependents**: do NOT promote. Closed work blocks nothing, so it can't promote a blocker.
- **\`external:*\` dependencies**: skipped explicitly. v1 doesn't resolve foreign workspaces; documented in code.
- **Cycles**: the walk terminates and returns the static priority for any node reached re-entrantly. Both nodes in the cycle still get correctly promoted via their non-cyclic dependents.
- **Pagination correctness**: when \`--sort=effective\` is in play, \`build_filters\` clears the SQL sort and the path falls through to \`apply_client_filters\` so all matching rows are fetched, computed, sorted, then paginated client-side. Sort-after-limit was a real risk here.

## Test coverage

10 unit tests covering: simple chain, branching, multi-hop propagation, no-demotion of higher-priority blockers, closed-dependent-no-promotion, external-deps-skipped, cycle handling, unrelated issues unchanged, sort ordering, and \`validate_sort_key('effective')\`. All pure-Rust without DB fixtures so they target the algorithm directly.

CLI-integration coverage stays in the existing \`tests/e2e_list_*.rs\` corpus — adding integration tests for the new flag is a clean follow-up if maintainers want that here.

## Disclosure

Local builds couldn't be fully verified due to a transitive-dep FreeBSD compile issue (\`fsqlite-vfs@0.1.3\` missing \`l_sysid\` in \`libc::flock\` on FreeBSD); upstream CI on Linux/macOS will validate. The algorithm tests are pure-Rust and should pass everywhere.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>