### PR TITLE
fix(sync): merge explicit worker JSONL into workspace target

### DIFF
--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -643,6 +643,20 @@ fn validate_sync_paths(
     })
 }
 
+fn resolve_merge_input_path(args: &SyncArgs, path_policy: &SyncPathPolicy) -> Result<PathBuf> {
+    match args.merge_from_jsonl.as_ref() {
+        Some(path) => {
+            let source_policy = validate_sync_paths(
+                &path_policy.beads_dir,
+                path,
+                path_policy.allow_external_jsonl,
+            )?;
+            Ok(source_policy.jsonl_path)
+        }
+        None => Ok(path_policy.jsonl_path.clone()),
+    }
+}
+
 fn validate_operator_requested_sync_path(beads_dir: &Path, jsonl_path: &Path) -> Result<()> {
     let git_check = validate_no_git_path(jsonl_path);
     if !git_check.is_allowed() {
@@ -2422,7 +2436,8 @@ fn execute_merge(
 ) -> Result<()> {
     info!("Starting 3-way merge");
     let beads_dir = &path_policy.beads_dir;
-    let jsonl_path = &path_policy.jsonl_path;
+    let target_jsonl_path = &path_policy.jsonl_path;
+    let merge_input_path = resolve_merge_input_path(args, path_policy)?;
 
     // 1. Load Base State (ancestor)
     let base = load_base_snapshot(beads_dir)?;
@@ -2454,19 +2469,23 @@ fn execute_merge(
 
     // 3. Load Right State (external JSONL)
     let mut right = HashMap::new();
-    if jsonl_path.exists() {
+    if merge_input_path.exists() {
         // `read_issues_from_jsonl` parses JSON line-by-line, which yields a
         // generic "Invalid JSON at line 1" error when the JSONL still
         // contains unresolved merge-conflict markers from a botched
         // `git merge` / `git pull`. A three-way merge on top of that state
         // would be nonsense, so scan for markers first and surface the
         // helpful error before we try to parse.
-        crate::sync::ensure_no_conflict_markers(jsonl_path)?;
-        for issue in read_issues_from_jsonl(jsonl_path)? {
+        crate::sync::ensure_no_conflict_markers(&merge_input_path)?;
+        for issue in read_issues_from_jsonl(&merge_input_path)? {
             right.insert(issue.id.clone(), issue);
         }
     }
-    debug!(right_count = right.len(), "Loaded external state (JSONL)");
+    debug!(
+        right_count = right.len(),
+        merge_input = %merge_input_path.display(),
+        "Loaded external state (JSONL)"
+    );
 
     // 4. Perform Merge
     let context = MergeContext::new(base, left, right);
@@ -2554,7 +2573,11 @@ fn execute_merge(
     storage.rebuild_child_counters_in_tx()?;
 
     // Force Export to update JSONL (ensure sync)
-    info!(path = %jsonl_path.display(), "Writing merged issues.jsonl");
+    info!(
+        path = %target_jsonl_path.display(),
+        merge_input = %merge_input_path.display(),
+        "Writing merged issues.jsonl"
+    );
     let export_config = ExportConfig {
         force: true, // Force export to ensure JSONL matches DB
         is_default_path: true,
@@ -2567,14 +2590,15 @@ fn execute_merge(
         max_parallel_workers: args.export_parallelism.unwrap_or(0),
     };
 
-    let (export_result, _) = export_to_jsonl_with_policy(storage, jsonl_path, &export_config)?;
+    let (export_result, _) =
+        export_to_jsonl_with_policy(storage, target_jsonl_path, &export_config)?;
     finalize_export(
         storage,
         &export_result,
         Some(&export_result.issue_hashes),
-        jsonl_path,
+        target_jsonl_path,
     )?;
-    save_base_snapshot_from_jsonl(jsonl_path, beads_dir)?;
+    save_base_snapshot_from_jsonl(target_jsonl_path, beads_dir)?;
 
     // Output success message
     if use_json {
@@ -2584,6 +2608,8 @@ fn execute_merge(
             "deleted_issues": report.deleted.len(),
             "conflicts": report.conflicts.len(),
             "resolution": resolution,
+            "merge_input": merge_input_path,
+            "target_jsonl": target_jsonl_path,
             "notes": report.notes,
         });
         ctx.json_pretty(&output);

--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -2487,6 +2487,86 @@ fn execute_merge(
         "Loaded external state (JSONL)"
     );
 
+    if args.merge_import_only {
+        let mut imported = Vec::new();
+        let mut skipped_tombstones = 0usize;
+        let source_issue_count = right.len();
+        let local_ids: HashSet<String> = left.keys().cloned().collect();
+
+        for (id, issue) in right {
+            if local_ids.contains(&id) {
+                continue;
+            }
+            if issue.status == crate::model::Status::Tombstone {
+                skipped_tombstones += 1;
+                continue;
+            }
+            imported.push(issue);
+        }
+
+        let skipped_existing = source_issue_count
+            .saturating_sub(imported.len())
+            .saturating_sub(skipped_tombstones);
+
+        info!(
+            imported = imported.len(),
+            skipped_existing, skipped_tombstones, "Add-only merge import calculated"
+        );
+
+        for issue in &imported {
+            storage.upsert_issue_for_import(issue)?;
+            storage.sync_labels_for_import(&issue.id, &issue.labels)?;
+            storage.sync_dependencies_for_import(&issue.id, &issue.dependencies)?;
+            storage.sync_comments_for_import(&issue.id, &issue.comments)?;
+        }
+
+        storage.rebuild_blocked_cache(true)?;
+        storage.rebuild_child_counters_in_tx()?;
+
+        let export_config = ExportConfig {
+            force: true,
+            is_default_path: true,
+            error_policy: ExportErrorPolicy::Strict,
+            retention_days,
+            beads_dir: Some(path_policy.beads_dir.clone()),
+            allow_external_jsonl: path_policy.allow_external_jsonl,
+            show_progress,
+            history: HistoryConfig::default(),
+            max_parallel_workers: args.export_parallelism.unwrap_or(0),
+        };
+
+        let (export_result, _) =
+            export_to_jsonl_with_policy(storage, target_jsonl_path, &export_config)?;
+        finalize_export(
+            storage,
+            &export_result,
+            Some(&export_result.issue_hashes),
+            target_jsonl_path,
+        )?;
+        save_base_snapshot_from_jsonl(target_jsonl_path, beads_dir)?;
+
+        if use_json {
+            let output = serde_json::json!({
+                "status": "success",
+                "mode": "merge-import-only",
+                "imported_issues": imported.len(),
+                "skipped_existing": skipped_existing,
+                "skipped_tombstones": skipped_tombstones,
+                "merge_input": merge_input_path,
+                "target_jsonl": target_jsonl_path,
+            });
+            ctx.json_pretty(&output);
+        } else {
+            ctx.success(&format!(
+                "Imported {} missing issue(s) from {}",
+                imported.len(),
+                merge_input_path.display()
+            ));
+        }
+
+        return Ok(());
+    }
+
     // 4. Perform Merge
     let context = MergeContext::new(base, left, right);
     let strategy = merge_conflict_resolution(args);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2249,6 +2249,13 @@ pub struct SyncArgs {
     #[arg(long)]
     pub merge: bool,
 
+    /// Read merge input from another JSONL file while writing this workspace's JSONL.
+    ///
+    /// This is useful for importing explicit worker-worktree bead exports without
+    /// treating that worker file as the sync target.
+    #[arg(long = "merge-from-jsonl", value_name = "PATH", requires = "merge")]
+    pub merge_from_jsonl: Option<PathBuf>,
+
     /// Show sync status (read-only)
     ///
     /// Displays hash comparison and freshness info without modifications.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2256,6 +2256,13 @@ pub struct SyncArgs {
     #[arg(long = "merge-from-jsonl", value_name = "PATH", requires = "merge")]
     pub merge_from_jsonl: Option<PathBuf>,
 
+    /// Only add issues from --merge-from-jsonl that are missing locally.
+    ///
+    /// This prevents stale worker JSONL snapshots from deleting or overwriting
+    /// canonical workspace issues while repairing worker-to-central divergence.
+    #[arg(long = "merge-import-only", requires = "merge_from_jsonl")]
+    pub merge_import_only: bool,
+
     /// Show sync status (read-only)
     ///
     /// Displays hash comparison and freshness info without modifications.

--- a/tests/e2e_basic_lifecycle.rs
+++ b/tests/e2e_basic_lifecycle.rs
@@ -842,6 +842,122 @@ fn e2e_sync_merge_resolution_flags_choose_db_or_jsonl() {
 }
 
 #[test]
+fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
+    let workspace = BrWorkspace::new();
+
+    let init = run_br(&workspace, ["init"], "init_no_db_merge_from");
+    assert!(init.status.success(), "init failed: {}", init.stderr);
+
+    let beads_dir = workspace.root.join(".beads");
+    fs::write(beads_dir.join("config.yaml"), "no-db: true\n").expect("write no-db config");
+
+    let create = run_br(
+        &workspace,
+        ["create", "Canonical issue before worker merge"],
+        "create_no_db_canonical_issue",
+    );
+    assert!(create.status.success(), "create failed: {}", create.stderr);
+
+    let jsonl_path = beads_dir.join("issues.jsonl");
+    let local_jsonl_before = fs::read_to_string(&jsonl_path).expect("read local jsonl");
+    let first_line = local_jsonl_before
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("local jsonl issue");
+    let mut worker_issue: Value = serde_json::from_str(first_line).expect("parse issue");
+    let original_id = worker_issue["id"].as_str().expect("issue id");
+    let worker_id = format!("{original_id}w");
+    worker_issue["id"] = Value::String(worker_id.clone());
+    worker_issue["title"] = Value::String("Worker-created bead".to_string());
+    worker_issue["content_hash"] = Value::Null;
+    worker_issue["created_at"] = Value::String(Utc::now().to_rfc3339());
+    worker_issue["updated_at"] = Value::String(Utc::now().to_rfc3339());
+
+    let worker_jsonl_path = workspace.root.join("worker-issues.jsonl");
+    let worker_issue_line = serde_json::to_string(&worker_issue).expect("serialize worker issue");
+    let worker_jsonl = format!("{local_jsonl_before}{worker_issue_line}\n");
+    fs::write(&worker_jsonl_path, &worker_jsonl).expect("write worker jsonl");
+
+    let worker_jsonl_arg = worker_jsonl_path.to_string_lossy().to_string();
+    let rejected = run_br(
+        &workspace,
+        vec![
+            "sync".to_string(),
+            "--merge".to_string(),
+            "--merge-from-jsonl".to_string(),
+            worker_jsonl_arg.clone(),
+            "--json".to_string(),
+        ],
+        "merge_from_external_without_opt_in",
+    );
+    assert!(
+        !rejected.status.success(),
+        "external merge source should require explicit opt-in"
+    );
+    assert!(
+        rejected.stderr.contains("outside .beads") || rejected.stdout.contains("outside .beads"),
+        "rejection should mention external path: stdout={} stderr={}",
+        rejected.stdout,
+        rejected.stderr
+    );
+
+    let merge = run_br(
+        &workspace,
+        vec![
+            "sync".to_string(),
+            "--merge".to_string(),
+            "--merge-from-jsonl".to_string(),
+            worker_jsonl_arg,
+            "--allow-external-jsonl".to_string(),
+            "--json".to_string(),
+        ],
+        "merge_from_worker_jsonl",
+    );
+    assert!(merge.status.success(), "merge failed: {}", merge.stderr);
+    let merge_payload = extract_json_payload(&merge.stdout);
+    let merge_json: Value = serde_json::from_str(&merge_payload).expect("merge json");
+    assert_eq!(merge_json["status"], "success");
+    assert_eq!(
+        fs::canonicalize(PathBuf::from(
+            merge_json["target_jsonl"].as_str().expect("target_jsonl")
+        ))
+        .expect("canonical target jsonl"),
+        fs::canonicalize(&jsonl_path).expect("canonical expected target")
+    );
+    assert_eq!(
+        fs::canonicalize(PathBuf::from(
+            merge_json["merge_input"].as_str().expect("merge_input")
+        ))
+        .expect("canonical merge input"),
+        fs::canonicalize(&worker_jsonl_path).expect("canonical expected input")
+    );
+
+    let local_jsonl_after = fs::read_to_string(&jsonl_path).expect("read merged local jsonl");
+    assert!(
+        local_jsonl_after
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .any(|issue| issue["id"].as_str() == Some(worker_id.as_str())),
+        "worker issue should be merged into the local JSONL"
+    );
+    assert_eq!(
+        fs::read_to_string(&worker_jsonl_path).expect("read worker jsonl"),
+        worker_jsonl,
+        "merge source must not be overwritten"
+    );
+
+    let show = run_br(
+        &workspace,
+        ["show", worker_id.as_str(), "--json"],
+        "show_worker_issue_after_merge",
+    );
+    assert!(show.status.success(), "show failed: {}", show.stderr);
+    let show_payload = extract_json_payload(&show.stdout);
+    let shown: Vec<Value> = serde_json::from_str(&show_payload).expect("show json");
+    assert_eq!(shown[0]["title"], "Worker-created bead");
+}
+
+#[test]
 fn e2e_sync_force_jsonl_merge_does_not_resurrect_local_tombstone() {
     let workspace = BrWorkspace::new();
 

--- a/tests/e2e_basic_lifecycle.rs
+++ b/tests/e2e_basic_lifecycle.rs
@@ -878,6 +878,17 @@ fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
     let worker_jsonl = format!("{local_jsonl_before}{worker_issue_line}\n");
     fs::write(&worker_jsonl_path, &worker_jsonl).expect("write worker jsonl");
 
+    let local_only = run_br(
+        &workspace,
+        ["create", "Local-only issue after worker snapshot"],
+        "create_no_db_local_only_after_worker_snapshot",
+    );
+    assert!(
+        local_only.status.success(),
+        "local-only create failed: {}",
+        local_only.stderr
+    );
+
     let worker_jsonl_arg = worker_jsonl_path.to_string_lossy().to_string();
     let rejected = run_br(
         &workspace,
@@ -886,6 +897,7 @@ fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
             "--merge".to_string(),
             "--merge-from-jsonl".to_string(),
             worker_jsonl_arg.clone(),
+            "--merge-import-only".to_string(),
             "--json".to_string(),
         ],
         "merge_from_external_without_opt_in",
@@ -908,6 +920,7 @@ fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
             "--merge".to_string(),
             "--merge-from-jsonl".to_string(),
             worker_jsonl_arg,
+            "--merge-import-only".to_string(),
             "--allow-external-jsonl".to_string(),
             "--json".to_string(),
         ],
@@ -917,6 +930,8 @@ fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
     let merge_payload = extract_json_payload(&merge.stdout);
     let merge_json: Value = serde_json::from_str(&merge_payload).expect("merge json");
     assert_eq!(merge_json["status"], "success");
+    assert_eq!(merge_json["mode"], "merge-import-only");
+    assert_eq!(merge_json["imported_issues"], 1);
     assert_eq!(
         fs::canonicalize(PathBuf::from(
             merge_json["target_jsonl"].as_str().expect("target_jsonl")
@@ -939,6 +954,13 @@ fn e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace() {
             .filter_map(|line| serde_json::from_str::<Value>(line).ok())
             .any(|issue| issue["id"].as_str() == Some(worker_id.as_str())),
         "worker issue should be merged into the local JSONL"
+    );
+    assert!(
+        local_jsonl_after
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .any(|issue| issue["title"].as_str() == Some("Local-only issue after worker snapshot")),
+        "add-only worker import must not delete local-only issues"
     );
     assert_eq!(
         fs::read_to_string(&worker_jsonl_path).expect("read worker jsonl"),

--- a/tests/storage_crud.rs
+++ b/tests/storage_crud.rs
@@ -104,6 +104,25 @@ fn create_issue_all_fields_populated() {
 }
 
 #[test]
+fn upsert_issue_for_import_accepts_sparse_jsonl_default_fields() {
+    let storage = test_db();
+    let mut issue = fixtures::issue("sparse-jsonl-import");
+    issue.description = None;
+    issue.design = None;
+    issue.acceptance_criteria = None;
+    issue.notes = None;
+
+    storage.upsert_issue_for_import(&issue).unwrap();
+
+    let retrieved = storage.get_issue(&issue.id).unwrap().expect("issue exists");
+    assert_eq!(retrieved.id, issue.id);
+    assert_eq!(retrieved.description, None);
+    assert_eq!(retrieved.design, None);
+    assert_eq!(retrieved.acceptance_criteria, None);
+    assert_eq!(retrieved.notes, None);
+}
+
+#[test]
 fn create_issue_records_created_event() {
     let mut storage = test_db();
     let issue = fixtures::issue("event-create");


### PR DESCRIPTION
## Status
Ready for review. Local regression tests pass and the ALPS copied-substrate smoke imported worker-filed beads without mutating the worker JSONL. A live repair attempt also proved why add-only mode is necessary: older worker snapshots can carry stale deletions under normal 3-way merge semantics.

## Why
Workers can create beads in worktree-local .beads/issues.jsonl files, but the orchestrator's canonical workspace had no safe way to import those rows. Existing br sync --merge has one JSONL path, so setting BEADS_JSONL or --jsonl-path points both the merge input and target at the worker file. A plain 3-way merge from older worker snapshots can also propagate deletions back into the canonical workspace.

## What changed
- Adds br sync --merge --merge-from-jsonl <PATH> to read merge input from an explicit worker JSONL while still writing the current workspace target JSONL.
- Adds --merge-import-only for add-only worker imports: import missing IDs, skip existing IDs/tombstones, never delete or overwrite canonical issues.
- Preserves the external-path guard: external merge sources require --allow-external-jsonl.
- Emits merge_input and target_jsonl in JSON output so callers can prove source/target separation.
- Adds regression coverage for no-db workspaces importing a worker JSONL without deleting local-only issues, plus sparse legacy JSONL imports with optional text fields.

## Verification
- cargo fmt --check
- cargo test e2e_sync_merge_from_jsonl_imports_worker_file_into_no_db_workspace --test e2e_basic_lifecycle
- cargo test e2e_sync_merge_resolution_flags_choose_db_or_jsonl --test e2e_basic_lifecycle
- cargo test upsert_issue_for_import_accepts_sparse_jsonl_default_fields --test storage_crud
- git diff --check
- Copied ALPS .beads smoke: imported josh-9tv8g from /private/tmp/alps-find-401-josh-9tv8g/.beads/issues.jsonl into copied canonical .beads; worker source hash unchanged.

## Reverse-direction
No migration required. Existing sync behavior is unchanged unless --merge-from-jsonl is provided; add-only repair requires --merge-import-only.