### PR TITLE
fix(sync): discard successful rebuild backups

### DIFF
--- a/src/cli/commands/sync.rs
+++ b/src/cli/commands/sync.rs
@@ -529,7 +529,7 @@ fn finalize_sync_result(
 ) -> Result<()> {
     match command_result {
         Ok(()) => {
-            open_result.discard_pending_recovery_backup();
+            open_result.discard_pending_recovery_backup()?;
             Ok(())
         }
         Err(command_err) => {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1166,8 +1166,55 @@ pub(crate) fn repair_database_from_jsonl_with_import_config(
     lock_timeout: Option<u64>,
     bootstrap_layer: &ConfigLayer,
     show_progress: bool,
-    mut import_config: ImportConfig,
+    import_config: ImportConfig,
 ) -> Result<(SqliteStorage, ImportResult, Vec<RecoveryBackupVerification>)> {
+    let (storage, import_result, backup_set) = repair_database_from_jsonl_with_backup(
+        beads_dir,
+        db_path,
+        jsonl_path,
+        lock_timeout,
+        bootstrap_layer,
+        show_progress,
+        import_config,
+    )?;
+    let verified_backups = backup_set.verified_files.clone();
+    Ok((storage, import_result, verified_backups))
+}
+
+fn repair_database_from_jsonl_retaining_backup(
+    beads_dir: &Path,
+    db_path: &Path,
+    jsonl_path: &Path,
+    lock_timeout: Option<u64>,
+    bootstrap_layer: &ConfigLayer,
+    show_progress: bool,
+    allow_external_jsonl: bool,
+) -> Result<(SqliteStorage, ImportResult, RecoveryBackupSet)> {
+    let mut import_config =
+        import_config_for_resolved_jsonl(beads_dir, db_path, jsonl_path, allow_external_jsonl);
+    import_config.show_progress = show_progress;
+    import_config.skip_prefix_validation = true;
+
+    repair_database_from_jsonl_with_backup(
+        beads_dir,
+        db_path,
+        jsonl_path,
+        lock_timeout,
+        bootstrap_layer,
+        show_progress,
+        import_config,
+    )
+}
+
+fn repair_database_from_jsonl_with_backup(
+    beads_dir: &Path,
+    db_path: &Path,
+    jsonl_path: &Path,
+    lock_timeout: Option<u64>,
+    bootstrap_layer: &ConfigLayer,
+    show_progress: bool,
+    mut import_config: ImportConfig,
+) -> Result<(SqliteStorage, ImportResult, RecoveryBackupSet)> {
     import_config.beads_dir = Some(beads_dir.to_path_buf());
     import_config.allow_external_jsonl |=
         implicit_external_jsonl_allowed(beads_dir, db_path, jsonl_path);
@@ -1203,7 +1250,7 @@ pub(crate) fn repair_database_from_jsonl_with_import_config(
         verified_backups = ?verified_backups,
         "SQLite rebuild from JSONL succeeded"
     );
-    Ok((storage, import_result, verified_backups))
+    Ok((storage, import_result, backup_set))
 }
 
 fn should_surface_recovery_error(recovery_err: &BeadsError) -> bool {
@@ -2172,6 +2219,44 @@ fn restore_database_family_after_failed_rebuild(backup_set: &RecoveryBackupSet) 
     Ok(())
 }
 
+fn discard_successful_recovery_backup(backup_set: &RecoveryBackupSet) -> Result<()> {
+    for (_, backup) in &backup_set.files {
+        match fs::remove_file(backup) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(BeadsError::WithContext {
+                    context: format!(
+                        "Successful database rebuild completed, but recovery backup '{}' could not be removed",
+                        backup.display()
+                    ),
+                    source: Box::new(err),
+                });
+            }
+        }
+    }
+
+    match fs::remove_dir(&backup_set.recovery_dir) {
+        Ok(()) => {}
+        Err(err)
+            if matches!(
+                err.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+            ) => {}
+        Err(err) => {
+            return Err(BeadsError::WithContext {
+                context: format!(
+                    "Successful database rebuild completed, but empty recovery directory '{}' could not be removed",
+                    backup_set.recovery_dir.display()
+                ),
+                source: Box::new(err),
+            });
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn recovery_dir_for_db_path(db_path: &Path, beads_dir: &Path) -> PathBuf {
     db_path
         .parent()
@@ -2419,7 +2504,7 @@ impl OpenStorageResult {
         // BusySnapshot conflicts.
         self.storage = SqliteStorage::open_memory()?;
 
-        let (storage, _, _) = repair_database_from_jsonl(
+        let (storage, _, backup_set) = repair_database_from_jsonl_retaining_backup(
             &self.paths.beads_dir,
             &self.paths.db_path,
             &self.paths.jsonl_path,
@@ -2431,7 +2516,7 @@ impl OpenStorageResult {
         self.storage = storage;
         self.loaded_jsonl_hash = None;
         self.auto_rebuilt = true;
-        self.pending_recovery_backup = None;
+        self.pending_recovery_backup = Some(backup_set);
         Ok(())
     }
 
@@ -2442,8 +2527,11 @@ impl OpenStorageResult {
             .map(|backup| backup.recovery_dir.as_path())
     }
 
-    pub(crate) fn discard_pending_recovery_backup(&mut self) {
-        self.pending_recovery_backup = None;
+    pub(crate) fn discard_pending_recovery_backup(&mut self) -> Result<()> {
+        if let Some(backup_set) = self.pending_recovery_backup.take() {
+            discard_successful_recovery_backup(&backup_set)?;
+        }
+        Ok(())
     }
 
     /// Restore the original database family after a deferred recovery prepared

--- a/tests/e2e_rebuild_cleanup.rs
+++ b/tests/e2e_rebuild_cleanup.rs
@@ -1,0 +1,58 @@
+mod common;
+
+use common::cli::{BrWorkspace, parse_created_id, run_br};
+use std::fs;
+
+fn assert_success(run: &common::cli::BrRun, label: &str) {
+    assert!(
+        run.status.success(),
+        "{label} failed\nstdout={}\nstderr={}",
+        run.stdout,
+        run.stderr
+    );
+}
+
+#[test]
+fn sync_import_rebuild_discards_successful_recovery_backups() {
+    let workspace = BrWorkspace::new();
+
+    let init = run_br(&workspace, ["init"], "init");
+    assert_success(&init, "init");
+
+    let create = run_br(&workspace, ["create", "Rebuild cleanup anchor"], "create");
+    assert_success(&create, "create");
+    let issue_id = parse_created_id(&create.stdout);
+
+    let flush = run_br(&workspace, ["sync", "--flush-only"], "flush");
+    assert_success(&flush, "flush");
+
+    let rebuild = run_br(
+        &workspace,
+        ["sync", "--import-only", "--rebuild"],
+        "import_rebuild",
+    );
+    assert_success(&rebuild, "import_rebuild");
+
+    let list = run_br(&workspace, ["show", &issue_id], "show_after_rebuild");
+    assert_success(&list, "show_after_rebuild");
+
+    let recovery_dir = workspace.root.join(".beads").join(".br_recovery");
+    let recovery_entries = if recovery_dir.exists() {
+        fs::read_dir(&recovery_dir)
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to read recovery dir {}: {err}",
+                    recovery_dir.display()
+                )
+            })
+            .count()
+    } else {
+        0
+    };
+    assert_eq!(
+        recovery_entries,
+        0,
+        "successful sync --import-only --rebuild must not leave recovery artifacts in {}",
+        recovery_dir.display()
+    );
+}


### PR DESCRIPTION
## Summary

- retain the delegated rebuild recovery backup set until sync command finalization
- discard only the backup files generated by a successful `sync --import-only --rebuild`
- remove the empty `.br_recovery` directory after successful cleanup while preserving pre-existing/manual recovery artifacts
- add an e2e regression covering successful rebuild cleanup

## Why

`br sync --import-only --rebuild` was leaving `.beads/.br_recovery/*.bak` files after successful rebuilds. Git hooks that call this command, such as post-merge health/rebuild hooks, were only triggering the issue; the residue came from `br` retaining successful recovery backups indefinitely.

The error path still restores the original database family from the retained backup set, so malformed import/rebuild failures keep their safety behavior.

## Verification

- `cargo test --test e2e_rebuild_cleanup sync_import_rebuild_discards_successful_recovery_backups -- --nocapture`
- `cargo test --test e2e_sync_failure_injection cli_import_malformed_preserves_db -- --nocapture`
- `cargo build --release`
- `rustfmt --check --edition 2024 src/config/mod.rs src/cli/commands/sync.rs tests/e2e_rebuild_cleanup.rs`
- `git diff --check`

Note: full `cargo fmt --check` currently reports unrelated formatting drift in `src/close_policy.rs` and `src/util/markdown_import.rs`; this PR intentionally leaves those files untouched.
