### PR TITLE
fix(cli): make list and ready defaults complete

### DIFF
--- a/agent_baseline/help/br_list_help.txt
+++ b/agent_baseline/help/br_list_help.txt
@@ -46,7 +46,7 @@ Options:
           Include closed issues (default excludes closed)
 
       --limit <LIMIT>
-          Maximum number of results (0 = unlimited, default: 50)
+          Maximum number of results (0 = unlimited, default: unlimited)
 
       --offset <OFFSET>
           Number of results to skip (for pagination, default: 0)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -305,7 +305,7 @@ br list [OPTIONS]
 **Output Options:**
 | Option | Description |
 |--------|-------------|
-| `--limit <N>` | Maximum results (0=unlimited, default: 50) |
+| `--limit <N>` | Maximum results (0=unlimited, default: unlimited) |
 | `--sort <FIELD>` | Sort by: priority, created_at, updated_at, title |
 | `-r, --reverse` | Reverse sort order |
 | `--long` | Long output format |
@@ -497,7 +497,7 @@ br ready [OPTIONS]
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--limit <N>` | Maximum results (default: 20) |
+| `--limit <N>` | Maximum results (default: unlimited, 0=unlimited) |
 | `--assignee <NAME>` | Filter by assignee |
 | `--unassigned` | Show only unassigned |
 | `-l, --label <LABEL>` | Filter by label (AND logic) |

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -3,7 +3,7 @@
 //! Classic bd-style LIKE search across title/description/id with list-like filters.
 
 use crate::cli::{
-    DEFAULT_LIST_LIMIT, DEFAULT_LIST_OFFSET, ListArgs, OutputFormat, SearchArgs,
+    DEFAULT_LIST_OFFSET, DEFAULT_SEARCH_LIMIT, ListArgs, OutputFormat, SearchArgs,
     resolve_output_format_with_outer_mode,
 };
 use crate::config;
@@ -469,7 +469,7 @@ fn build_filters(args: &ListArgs) -> Result<ListFilters> {
         include_deferred,
         include_templates: false,
         title_contains: args.title_contains.clone(),
-        limit: Some(args.limit.unwrap_or(DEFAULT_LIST_LIMIT)),
+        limit: Some(args.limit.unwrap_or(DEFAULT_SEARCH_LIMIT)),
         offset: Some(args.offset.unwrap_or(DEFAULT_LIST_OFFSET)),
         sort: args.sort.clone(),
         reverse: args.reverse,
@@ -852,7 +852,7 @@ mod tests {
     fn test_search_build_filters_applies_list_defaults_when_cli_omits_pagination() {
         let filters = build_filters(&ListArgs::default()).expect("build filters");
 
-        assert_eq!(filters.limit, Some(DEFAULT_LIST_LIMIT));
+        assert_eq!(filters.limit, Some(DEFAULT_SEARCH_LIMIT));
         assert_eq!(filters.offset, Some(DEFAULT_LIST_OFFSET));
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,8 +19,9 @@ use crate::model::{IssueType, Status};
 
 pub mod commands;
 
-pub(crate) const DEFAULT_LIST_LIMIT: usize = 50;
+pub(crate) const DEFAULT_LIST_LIMIT: usize = 0;
 pub(crate) const DEFAULT_LIST_OFFSET: usize = 0;
+pub(crate) const DEFAULT_SEARCH_LIMIT: usize = 50;
 
 #[derive(Clone, Copy)]
 enum IssueCompletionFilter {
@@ -1681,7 +1682,7 @@ pub struct ListArgs {
     #[arg(long, short = 'a')]
     pub all: bool,
 
-    /// Maximum number of results (0 = unlimited, default: 50)
+    /// Maximum number of results (0 = unlimited, default: unlimited)
     #[arg(long)]
     pub limit: Option<usize>,
 
@@ -2313,8 +2314,8 @@ pub struct UndeferArgs {
 #[derive(Args, Debug, Clone, Default)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct ReadyArgs {
-    /// Maximum number of issues to return (default: 20, 0 = unlimited)
-    #[arg(long, default_value_t = 20)]
+    /// Maximum number of issues to return (default: unlimited, 0 = unlimited)
+    #[arg(long, default_value_t = 0)]
     pub limit: usize,
 
     /// Filter by assignee (no value = current actor)

--- a/tests/e2e_list_comprehensive.rs
+++ b/tests/e2e_list_comprehensive.rs
@@ -15,7 +15,8 @@
 
 mod common;
 
-use common::cli::{BrWorkspace, parse_list_issues, parse_list_page, run_br};
+use common::cli::{BrWorkspace, parse_json_value, parse_list_issues, parse_list_page, run_br};
+use std::collections::HashSet;
 
 fn parse_created_id(stdout: &str) -> String {
     let line = stdout.lines().next().unwrap_or("");
@@ -849,6 +850,85 @@ fn e2e_list_limit_zero_with_offset_reports_unpaginated_total() {
     assert_eq!(page["limit"].as_u64(), Some(0));
     assert_eq!(page["offset"].as_u64(), Some(2));
     assert_eq!(page["has_more"].as_bool(), Some(false));
+}
+
+#[test]
+fn e2e_list_default_is_unlimited_and_matches_show_truth() {
+    let _log = common::test_log("e2e_list_default_is_unlimited_and_matches_show_truth");
+    let workspace = BrWorkspace::new();
+    let init = run_br(&workspace, ["init"], "init");
+    assert!(init.status.success(), "init failed: {}", init.stderr);
+
+    let mut ids = Vec::new();
+    for index in 0..60 {
+        let title = format!("Measurement integrity issue {index:02}");
+        let create = run_br(
+            &workspace,
+            ["create", title.as_str()],
+            &format!("create_{index:02}"),
+        );
+        assert!(
+            create.status.success(),
+            "create {index} failed: {}",
+            create.stderr
+        );
+        ids.push(parse_created_id(&create.stdout));
+    }
+
+    let closed_id = ids.first().expect("created ids").clone();
+    let close = run_br(
+        &workspace,
+        [
+            "close",
+            &closed_id,
+            "--reason",
+            "measurement integrity regression",
+        ],
+        "close_first_issue",
+    );
+    assert!(close.status.success(), "close failed: {}", close.stderr);
+
+    let closed_show = run_br(&workspace, ["show", &closed_id, "--json"], "show_closed");
+    assert!(
+        closed_show.status.success(),
+        "show closed failed: {}",
+        closed_show.stderr
+    );
+    let closed_details = parse_json_value(&closed_show.stdout);
+    assert_eq!(closed_details[0]["status"], "closed");
+
+    let list = run_br(&workspace, ["list", "--json"], "list_default_unlimited");
+    assert!(list.status.success(), "list failed: {}", list.stderr);
+
+    let page = parse_list_page(&list.stdout);
+    let issues = page["issues"].as_array().expect("issues array");
+
+    assert_eq!(issues.len(), ids.len() - 1);
+    assert_eq!(page["total"].as_u64(), Some((ids.len() - 1) as u64));
+    assert_eq!(page["limit"].as_u64(), Some(0));
+    assert_eq!(page["offset"].as_u64(), Some(0));
+    assert_eq!(page["has_more"].as_bool(), Some(false));
+
+    let mut listed_ids = HashSet::new();
+    for issue in issues {
+        let id = issue["id"].as_str().expect("listed issue id").to_string();
+        assert_ne!(
+            id, closed_id,
+            "closed issue must not appear in default list"
+        );
+        assert!(listed_ids.insert(id.clone()), "duplicate list id {id}");
+
+        let show = run_br(
+            &workspace,
+            ["show", id.as_str(), "--json"],
+            &format!("show_{}", id.replace('-', "_")),
+        );
+        assert!(show.status.success(), "show {id} failed: {}", show.stderr);
+        let details = parse_json_value(&show.stdout);
+        assert_eq!(details[0]["id"], id);
+        assert_eq!(details[0]["status"], issue["status"]);
+        assert_eq!(details[0]["status"], "open");
+    }
 }
 
 // =============================================================================

--- a/tests/e2e_ready_limit.rs
+++ b/tests/e2e_ready_limit.rs
@@ -1,5 +1,6 @@
 mod common;
-use common::cli::{BrWorkspace, parse_list_issues, run_br};
+use common::cli::{BrWorkspace, extract_json_payload, parse_created_id, parse_list_issues, run_br};
+use std::collections::HashSet;
 
 #[test]
 fn test_ready_limit_with_external_blockers() {
@@ -65,4 +66,45 @@ fn test_ready_limit_with_external_blockers() {
             "Blocked issue {id} returned in ready list"
         );
     }
+}
+
+#[test]
+fn ready_default_is_unlimited_and_does_not_hide_ready_p0s() {
+    let workspace = BrWorkspace::new();
+    let init = run_br(&workspace, ["init"], "init");
+    assert!(init.status.success(), "init failed: {}", init.stderr);
+
+    let mut created_ids = HashSet::new();
+    for index in 0..25 {
+        let title = format!("Ready P0 measurement issue {index:02}");
+        let create = run_br(
+            &workspace,
+            ["create", title.as_str(), "-p", "0"],
+            &format!("create_ready_p0_{index:02}"),
+        );
+        assert!(
+            create.status.success(),
+            "create ready issue {index} failed: {}",
+            create.stderr
+        );
+        assert!(created_ids.insert(parse_created_id(&create.stdout)));
+    }
+
+    let ready = run_br(&workspace, ["ready", "--json"], "ready_default_unlimited");
+    assert!(ready.status.success(), "ready failed: {}", ready.stderr);
+    let payload = extract_json_payload(&ready.stdout);
+    let ready_issues: Vec<serde_json::Value> =
+        serde_json::from_str(&payload).expect("ready JSON array");
+
+    assert_eq!(
+        ready_issues.len(),
+        created_ids.len(),
+        "default ready must not silently truncate ready P0s"
+    );
+
+    let returned_ids: HashSet<String> = ready_issues
+        .iter()
+        .map(|issue| issue["id"].as_str().expect("ready issue id").to_string())
+        .collect();
+    assert_eq!(returned_ids, created_ids);
 }


### PR DESCRIPTION
## Summary
- make `br list` default to unlimited results while preserving explicit pagination and search's existing default cap
- make `br ready` default to unlimited results so dispatch tooling cannot silently hide ready P0 work after 20 rows
- add e2e regressions for list-vs-show truth beyond 50 rows and ready P0 visibility beyond 20 rows

## Flywheel beads
- `flywheel-auq6p`: `br list` measurement-integrity default pagination false count
- `flywheel-oxc14`: `br ready` default limit-20 ready-queue truncation

## Verification
- `/Users/josh/.cargo/bin/cargo test e2e_list_default_is_unlimited_and_matches_show_truth --test e2e_list_comprehensive`
- `/Users/josh/.cargo/bin/cargo test ready_default_is_unlimited_and_does_not_hide_ready_p0s --test e2e_ready_limit`
- `/Users/josh/.cargo/bin/cargo test build_filters_applies`
- `/Users/josh/.cargo/bin/cargo check --all-targets`
- `/Users/josh/.cargo/bin/cargo clippy --all-targets -- -D warnings`
- `/Users/josh/.cargo/bin/cargo fmt --check`
- `git diff --check`

Notes: RCH was not available on PATH in this shell, so required Cargo checks were run directly. Agent Mail file reservation was attempted but the current MCP surface failed with the known JSON-RPC deserialize transport error.