### PR TITLE
fix(doctor): honor --no-db side-effect contract

### DIFF
--- a/src/cli/commands/doctor.rs
+++ b/src/cli/commands/doctor.rs
@@ -780,6 +780,14 @@ fn has_error(checks: &[CheckResult]) -> bool {
         .any(|check| matches!(check.status, CheckStatus::Error))
 }
 
+fn no_db_mode(beads_dir: &Path, cli: &config::CliOverrides) -> bool {
+    let Ok(startup_layer) = config::load_startup_config(beads_dir) else {
+        return cli.no_db.unwrap_or(false);
+    };
+    let merged_layer = config::ConfigLayer::merge_layers(&[startup_layer, cli.as_layer()]);
+    config::no_db_from_layer(&merged_layer).unwrap_or(false)
+}
+
 fn has_non_ok(checks: &[CheckResult]) -> bool {
     checks
         .iter()
@@ -9984,7 +9992,7 @@ fn collect_doctor_report_with_mode(
     paths: &config::ConfigPaths,
     mode: DoctorInspectionMode,
 ) -> Result<DoctorRun> {
-    collect_doctor_report_with_mode_and_db_override(beads_dir, paths, None, mode)
+    collect_doctor_report_with_mode_and_db_override(beads_dir, paths, None, false, mode)
 }
 
 fn collect_doctor_report_for_cli(
@@ -9992,10 +10000,12 @@ fn collect_doctor_report_for_cli(
     paths: &config::ConfigPaths,
     cli: &config::CliOverrides,
 ) -> Result<DoctorRun> {
+    let no_db = no_db_mode(beads_dir, cli);
     collect_doctor_report_with_mode_and_db_override(
         beads_dir,
         paths,
         cli.db.as_ref(),
+        no_db,
         DoctorInspectionMode::Full,
     )
 }
@@ -10004,6 +10014,7 @@ fn collect_doctor_report_with_mode_and_db_override(
     beads_dir: &Path,
     paths: &config::ConfigPaths,
     db_override: Option<&PathBuf>,
+    no_db: bool,
     mode: DoctorInspectionMode,
 ) -> Result<DoctorRun> {
     let mut checks = Vec::new();
@@ -10015,9 +10026,11 @@ fn collect_doctor_report_with_mode_and_db_override(
     // Pass-5 cycle 28: writability of `.doctor/` so the next --repair
     // won't crash deep inside the chokepoint.
     check_doctor_runs_creatable(repo_root, &mut checks);
-    // Pass-5 cycle 30: writability of the active DB recovery dir so the
-    // next --repair won't crash mid-backup.
-    check_recovery_dir_writable(&paths.db_path, beads_dir, &mut checks);
+    if !no_db {
+        // Pass-5 cycle 30: writability of the active DB recovery dir so the
+        // next --repair won't crash mid-backup.
+        check_recovery_dir_writable(&paths.db_path, beads_dir, &mut checks);
+    }
     // Pass-5 cycle 31: writability of `.beads/.write.lock` so we don't
     // mask EACCES failures as cryptic "could not open lock" errors.
     check_write_lock_writable(beads_dir, &mut checks);
@@ -10047,18 +10060,48 @@ fn collect_doctor_report_with_mode_and_db_override(
     check_startup_cache(beads_dir, db_override, &mut checks);
 
     let (jsonl_path, jsonl_count) = inspect_doctor_jsonl(beads_dir, paths, &mut checks);
-    // Pass-5 cycle 22: db-to-selected-jsonl size ratio (VACUUM candidate).
-    check_db_bloat_vs_jsonl(&paths.db_path, jsonl_path.as_deref(), &mut checks);
-    // Pass-5 cycle 23: selected DB WAL sidecar oversized (checkpoint candidate).
-    check_wal_oversized(&paths.db_path, &mut checks);
-    inspect_doctor_database(
-        beads_dir,
-        &paths.db_path,
-        jsonl_path.as_deref(),
-        jsonl_count,
-        mode,
-        &mut checks,
-    );
+    if no_db {
+        push_check(
+            &mut checks,
+            "db.no_db_mode",
+            CheckStatus::Ok,
+            Some("--no-db active; skipped SQLite-backed doctor checks".to_string()),
+            Some(serde_json::json!({
+                "db_path": paths.db_path.display().to_string(),
+                "skipped_checks": [
+                    "permissions.recovery_dir",
+                    "db_bloat",
+                    "wal_size",
+                    "db.recovery_artifacts",
+                    "db.recovery_artifacts.aged",
+                    "db.sidecars",
+                    "db.exists",
+                    "db.open",
+                    "schema.tables",
+                    "schema.columns",
+                    "sqlite.integrity_check",
+                    "sqlite3.integrity_check",
+                    "db.recoverable_anomalies",
+                    "counts.db_vs_jsonl",
+                    "sync.metadata",
+                    "db.write_probe"
+                ]
+            })),
+        );
+    } else {
+        // Pass-5 cycle 22: db-to-selected-jsonl size ratio (VACUUM candidate).
+        check_db_bloat_vs_jsonl(&paths.db_path, jsonl_path.as_deref(), &mut checks);
+        // Pass-5 cycle 23: selected DB WAL sidecar oversized (checkpoint candidate).
+        check_wal_oversized(&paths.db_path, &mut checks);
+        inspect_doctor_database(
+            beads_dir,
+            &paths.db_path,
+            jsonl_path.as_deref(),
+            jsonl_count,
+            mode,
+            &mut checks,
+        );
+    }
 
     let classification = classify_doctor_checks(&paths.db_path, &paths.jsonl_path, &checks);
     let reliability_audit = classification.audit_record("doctor.inspect");
@@ -10441,10 +10484,12 @@ pub fn execute(args: &DoctorArgs, cli: &config::CliOverrides, ctx: &OutputContex
     } else {
         DoctorInspectionMode::Full
     };
+    let no_db = no_db_mode(&beads_dir, cli);
     let mut initial = collect_doctor_report_with_mode_and_db_override(
         &beads_dir,
         &paths,
         cli.db.as_ref(),
+        no_db,
         inspection_mode,
     )?;
 

--- a/tests/e2e_global_flags.rs
+++ b/tests/e2e_global_flags.rs
@@ -7,7 +7,62 @@ mod common;
 
 use common::cli::{BrWorkspace, extract_json_payload, parse_list_issues, run_br};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use std::fs;
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, PartialEq, Eq)]
+enum BeadsTreeEntry {
+    Dir,
+    File {
+        modified_nanos: u128,
+        bytes: Vec<u8>,
+    },
+}
+
+fn snapshot_beads_tree(root: &Path) -> BTreeMap<String, BeadsTreeEntry> {
+    let beads_dir = root.join(".beads");
+    let mut snapshot = BTreeMap::new();
+
+    for entry in walkdir::WalkDir::new(&beads_dir)
+        .sort_by_file_name()
+        .into_iter()
+    {
+        let entry = entry.expect("walk .beads");
+        let path = entry.path();
+        let rel = path
+            .strip_prefix(root)
+            .expect("path below root")
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        if entry.file_type().is_dir() {
+            snapshot.insert(rel, BeadsTreeEntry::Dir);
+            continue;
+        }
+
+        if entry.file_type().is_file() {
+            let metadata = fs::metadata(path).expect("file metadata");
+            let modified_nanos = metadata
+                .modified()
+                .expect("file modified time")
+                .duration_since(UNIX_EPOCH)
+                .expect("modified after epoch")
+                .as_nanos();
+            let bytes = fs::read(path).expect("read file");
+            snapshot.insert(
+                rel,
+                BeadsTreeEntry::File {
+                    modified_nanos,
+                    bytes,
+                },
+            );
+        }
+    }
+
+    snapshot
+}
 
 fn parse_created_id(stdout: &str) -> String {
     let line = stdout.lines().next().unwrap_or("");
@@ -647,6 +702,54 @@ fn e2e_no_db_hard_delete_flushes_jsonl() {
         !after.contains(&format!("\"id\":\"{issue_id}\"")),
         "hard delete in --no-db mode should remove the issue from JSONL"
     );
+}
+
+#[test]
+fn e2e_no_db_flag_doctor_side_effect_free() {
+    let _log = common::test_log("e2e_no_db_flag_doctor_side_effect_free");
+    let workspace = BrWorkspace::new();
+
+    let init = run_br(&workspace, ["init"], "init");
+    assert!(init.status.success(), "init failed: {}", init.stderr);
+
+    let create = run_br(&workspace, ["create", "No-DB doctor test"], "create");
+    assert!(create.status.success(), "create failed: {}", create.stderr);
+
+    let sync = run_br(&workspace, ["sync", "--flush-only"], "sync_flush");
+    assert!(sync.status.success(), "sync flush failed: {}", sync.stderr);
+
+    let before = snapshot_beads_tree(&workspace.root);
+    let doctor = run_br(&workspace, ["--no-db", "doctor", "--json"], "doctor_no_db");
+
+    let payload = extract_json_payload(&doctor.stdout);
+    let json: Value = serde_json::from_str(&payload).expect("valid JSON");
+    let checks = json["checks"].as_array().expect("checks array");
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["name"] == "db.no_db_mode" && check["status"] == "ok"),
+        "doctor should explicitly report SQLite checks skipped in no-db mode: {json}"
+    );
+
+    for skipped_check in [
+        "db.exists",
+        "db.open",
+        "schema.tables",
+        "schema.columns",
+        "sqlite.integrity_check",
+        "sqlite3.integrity_check",
+        "counts.db_vs_jsonl",
+        "sync.metadata",
+        "db.write_probe",
+    ] {
+        assert!(
+            !checks.iter().any(|check| check["name"] == skipped_check),
+            "doctor --no-db must not run SQLite-backed check {skipped_check}: {json}"
+        );
+    }
+
+    let after = snapshot_beads_tree(&workspace.root);
+    assert_eq!(after, before, "doctor --no-db mutated .beads");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

`br doctor --no-db` still opened the repo SQLite DB and ran DB-backed checks, which can create SQLite sidecar files or trigger schema/mtime churn despite the advertised no-db contract.

This changes doctor to resolve the same startup/CLI `no-db` flag used by the storage layer and, when active, skip SQLite-backed checks entirely. The JSON report now emits an explicit `db.no_db_mode` ok check with the skipped check names instead of silently behaving like DB mode.

## Verification

Run on a clean worktree based on current `Dicklesworthstone/main`:

- `cargo test --test e2e_global_flags e2e_no_db_flag_doctor_side_effect_free -- --nocapture` -> 1/0
- `cargo test --test e2e_global_flags -- --nocapture` -> 199/0
- `cargo fmt --check`

## Regression proof

The new E2E test snapshots `.beads` file contents and mtimes before/after `br --no-db doctor --json`, asserts the snapshot is unchanged, and asserts SQLite-backed checks such as `schema.tables`, `sqlite.integrity_check`, `sqlite3.integrity_check`, `counts.db_vs_jsonl`, `sync.metadata`, and `db.write_probe` are absent while `db.no_db_mode` is present.

Manual temp-repo comparison:

- installed `br`: `--no-db doctor --json` still reported SQLite-backed checks and created `.beads/beads.db-shm`
- rebuilt `target/debug/br`: `--no-db doctor --json` reported `db.no_db_mode`, skipped SQLite-backed checks, and left the `.beads` file list unchanged
