### PR TITLE
Fix MCP openWorldHint for manage_dependencies

### DIFF
--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2768,9 +2768,7 @@ impl ToolHandler for ManageDependenciesTool {
                 read_only: None,
                 destructive: Some(false),
                 idempotent: None,
-                open_world_hint: Some(
-                    "list action is read-only; add is idempotent; remove is not".into(),
-                ),
+                open_world_hint: Some(false),
             }),
         }
     }
@@ -4433,6 +4431,19 @@ mod tests {
                 "equality": "batch dependency adds verified by final storage state and per-item ok counts",
             })
         );
+    }
+
+    #[test]
+    fn manage_dependencies_annotations_use_closed_world_hint() {
+        let temp = TempDir::new().expect("tempdir");
+        let state = mcp_test_state(&temp);
+        let tool = ManageDependenciesTool::new(state);
+        let annotations = tool.definition().annotations.expect("annotations");
+
+        assert_eq!(annotations.destructive, Some(false));
+        assert_eq!(annotations.idempotent, None);
+        assert_eq!(annotations.read_only, None);
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
This updates the `manage_dependencies` MCP tool annotation to use the MCP `openWorldHint` field as a boolean closed-world hint instead of an explanatory string.

This is part of the MCP wire-format compatibility work needed for Codex GUI to load the Beads MCP server successfully. Codex GUI expects MCP tool annotations to follow the current spec, where `openWorldHint` is a boolean hint rather than a string.

It also adds a regression test for the emitted annotation shape.

https://github.com/Dicklesworthstone/fastmcp_rust/pull/35 is required for this to work.

## Maintainer notes

MCP `ToolAnnotations.openWorldHint` is a boolean hint. This should land after the corresponding FastMCP protocol fix that changes `open_world_hint` from `Option<String>` to `Option<bool>`.

References:

- https://modelcontextprotocol.io/specification/2025-11-25/server/tools
- https://blog.modelcontextprotocol.io/posts/2026-03-16-tool-annotations/
