### PR TITLE
docs: add an optional docs site (static, searchable, agent-native), preview inside

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: docs
+
+# Docs-as-code: kura.toml + this workflow. The kurajs/pages action renders docs/ into a searchable,
+# agent-native static site and deploys it to GitHub Pages. It auto-detects the deploy path and fixes
+# repo-relative links, so there is nothing else to configure.
+
+on:
+  push:
+    branches: [main, master, docs/kura-site]
+    paths:
+      - "docs/**"
+      - "kura.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: docs-pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: kurajs/pages@v1

--- a/kura.toml
+++ b/kura.toml
@@ -1,0 +1,72 @@
+# beads_rust docs site — the ONLY config. The kurajs/pages action reads this + renders docs/ into
+# the site (auto-detects the deploy path, fixes repo-relative links, ships client-side search + agent
+# surfaces). beads_rust is Rust, so nothing at the repo root is touched.
+
+markdown  = "commonmark"
+base_path = ""
+[site]
+name        = "beads_rust"
+description = "Fast Rust port of Steve Yegge's beads: a local-first, non-invasive issue tracker storing tasks in SQLite with JSONL export for git collaboration."
+[deploy]
+target    = "github-pages"
+[content]
+sources = []
+[[nav.tabs]]
+title = "Guide"
+groups = ["guide"]
+[[nav.tabs]]
+title = "For agents"
+groups = ["agents"]
+[[nav.tabs]]
+title = "Internals"
+groups = ["architecture", "porting"]
+[[nav.tabs]]
+title = "Development"
+groups = ["dev", "notes"]
+[nav.groups.guide]
+title = "Guide"
+pages = [
+  { slug = "INSTALLING", title = "Installation" }, { slug = "CLI_REFERENCE", title = "CLI reference" },
+  { slug = "AGENT_INTEGRATION", title = "AI agent integration" }, { slug = "VCS_INTEGRATION", title = "VCS integration" },
+  { slug = "SYNC_SAFETY", title = "Sync safety model" }, { slug = "TROUBLESHOOTING", title = "Troubleshooting" },
+]
+[nav.groups.agents]
+title = "For agents"
+pages = [
+  { slug = "agent/QUICKSTART", title = "Quickstart" }, { slug = "agent/EXAMPLES", title = "Examples" },
+  { slug = "agent/AGENTS", title = "AGENTS.md entry point" }, { slug = "agent/SCHEMA", title = "Schemas" },
+  { slug = "agent/ROBOT_MODE", title = "Robot mode (JSON/TOON)" }, { slug = "agent/ERRORS", title = "Errors" },
+  { slug = "agent/AGENT_FRIENDLINESS_REPORT", title = "Agent-friendliness report" },
+  { slug = "agent/AGENT_FRIENDLY_CHANGELOG", title = "Agent-friendly changelog" },
+]
+[nav.groups.architecture]
+title = "Architecture & design"
+pages = [
+  { slug = "ARCHITECTURE", title = "Architecture overview" }, { slug = "ARTIFACT_LOG_SCHEMA", title = "Artifact log schema" },
+  { slug = "WRITE_COMBINING_QUEUE_DESIGN", title = "Write-combining queue" }, { slug = "COORDINATION_EVIDENCE", title = "Coordination evidence" },
+  { slug = "SWARM_SCALE_TUNING", title = "Swarm-scale tuning" }, { slug = "reliability/HEALTH_CONTRACT", title = "Workspace health contract" },
+]
+[nav.groups.porting]
+title = "Porting notes"
+pages = [
+  { slug = "porting/EXISTING_BEADS_STRUCTURE_AND_ARCHITECTURE", title = "Existing beads structure" },
+  { slug = "porting/PLAN_TO_PORT_BEADS_WITH_SQLITE_AND_ISSUES_JSONL_TO_RUST", title = "Port plan" },
+  { slug = "porting/PROPOSED_ARCHITECTURE_FOR_BR_USING_RUST_BEST_PRACTICES", title = "Proposed architecture" },
+]
+[nav.groups.dev]
+title = "Development"
+pages = [
+  { slug = "TESTING_GUIDELINES", title = "Testing guidelines" }, { slug = "TEST_HARNESS", title = "Test harness" },
+  { slug = "SNAPSHOT_TESTING", title = "Snapshot testing" }, { slug = "E2E_COVERAGE_MATRIX", title = "E2E coverage matrix" },
+  { slug = "E2E_SYNC_TESTS", title = "E2E sync tests" }, { slug = "SYNC_MAINTENANCE_CHECKLIST", title = "Sync maintenance checklist" },
+  { slug = "CI_SUPPLY_CHAIN", title = "CI supply chain" }, { slug = "operations/UPGRADE_LOG", title = "Dependency upgrade log" },
+  { slug = "plans/RICH_INTEGRATION_PLAN", title = "Rich integration plan" },
+]
+[nav.groups.notes]
+title = "Audit logs"
+pages = [
+  { slug = "audit_bd_to_br_2026_05_09", title = "Audit: bd to br migration" },
+  { slug = "audit_forced_cycle_close_2026_05_09", title = "Audit: forced-cycle-close" },
+  { slug = "audit_id_pinning_2026_05_09", title = "Audit: ID pinning" },
+  { slug = "snapshot_review_2026_05_09", title = "Snapshot review" },
+]


### PR DESCRIPTION
Hi @Dicklesworthstone 👋 ran across beads_rust and really like it (local-first, JSONL-for-git, and genuinely agent-first docs). You've already written a thorough set of docs in `docs/`, but they only live on GitHub right now, so I built a docs-generation tool called Kura and, on a whim, forked beads_rust and rendered them into a searchable docs site to see how it'd look.

**Live preview: https://linyiru.github.io/beads_rust/**

A few things it does:

- **Docs-as-code**: renders the Markdown already in `docs/` into a fully static HTML site. Your writing flow doesn't change at all. You edit the same `.md` files and the site rebuilds itself.
- **Built-in search**: client-side, instant, no server.
- **GitHub Pages**: fully static, so hosting is free.
- **Dead-simple config**: one `kura.toml` at the root (nav plus which folder holds the docs), and a GitHub Actions workflow that deploys on every docs change.
- **Agent-friendly**: every page is also served as `.md` for AI/agents, plus a built-in `/llms.txt` whole-site map (which felt especially fitting given beads_rust's `AGENT_INTEGRATION.md` and agent-first `docs/agent/`).

**Minimal intrusion:** this PR adds only **2 files**, `kura.toml` and `.github/workflows/docs.yml`. beads_rust is Rust, so nothing at the repo root is touched.

**What you get once this is merged:** the same site at `https://dicklesworthstone.github.io/beads_rust/` automatically (that URL is where it will live after merge, not live yet). GitHub Pages hosts it for free, and you can point a custom domain at it anytime. From then on it just tracks your `docs/`, with no extra maintenance.

_(One small touch: your docs hand-write a "Table of Contents" list fenced with `---`; the site folds that into a collapsed toggle and drops the duplicate, since it already renders a right-rail "On this page".)_

Totally optional. Mostly I'd love your feedback: does this make beads_rust easier to explore and adopt? Happy to adjust anything (nav grouping, theme, sections) or close it if it's not a fit.

_(And if it is useful: you have a whole shelf of agent / dev-tooling repos with great docs and no site. It is 2 files each, so I would be glad to do the same for a few more.)_
