### PR TITLE
fix(storage): read user_version through the connection, not raw file-header bytes

### DIFF
--- a/src/storage/sqlite.rs
+++ b/src/storage/sqlite.rs
@@ -1038,7 +1038,16 @@ impl SqliteStorage {
             conn.execute(&format!("PRAGMA busy_timeout={timeout_ms}"))?;
         }
 
-        let schema_current = database_header_user_version(path)
+        // Read the schema version through the connection, not the raw file
+        // header: header bytes miss WAL-resident values, so with another
+        // process's uncheckpointed WAL a current database reads as stale and
+        // schema gets re-applied against live data (observed corrupting
+        // point lookups under two concurrent agent sessions). Fall back to
+        // the header peek if the PRAGMA itself errors (e.g. corrupted file),
+        // so doctor can still open and diagnose instead of re-applying
+        // schema over the corruption.
+        let schema_current = connection_user_version(&conn)
+            .or_else(|| database_header_user_version(path))
             .is_some_and(|version| version >= u32::try_from(CURRENT_SCHEMA_VERSION).unwrap_or(0));
         let runtime_compatible = runtime_schema_compatible(&conn);
 
@@ -1060,8 +1069,10 @@ impl SqliteStorage {
 
     pub(crate) fn open_current_read_only(path: &Path) -> Result<Option<Self>> {
         let current_schema_version = u32::try_from(CURRENT_SCHEMA_VERSION).unwrap_or(0);
-        if database_header_user_version(path).is_none_or(|version| version < current_schema_version)
-        {
+        // Cheap pre-filter only: the raw header can lag the true value when
+        // user_version lives in an uncheckpointed WAL, so a low header value
+        // must not disqualify the database. Only a missing/invalid file does.
+        if database_header_user_version(path).is_none() {
             return Ok(None);
         }
 
@@ -1069,6 +1080,12 @@ impl SqliteStorage {
             path.to_string_lossy().as_ref(),
             OpenFlags::SQLITE_OPEN_READ_ONLY,
         )?;
+        if connection_user_version(&conn)
+            .or_else(|| database_header_user_version(path))
+            .is_none_or(|version| version < current_schema_version)
+        {
+            return Ok(None);
+        }
         Ok(Some(Self {
             conn,
             mutation_count: 0,
@@ -10932,6 +10949,15 @@ fn remove_temp_db_files(path: &Path) {
     }
 }
 
+/// Read `PRAGMA user_version` through an open connection. Unlike the raw
+/// file-header peek below, this sees WAL-resident values, so it stays correct
+/// while other sessions have written but not yet checkpointed.
+fn connection_user_version(conn: &Connection) -> Option<u32> {
+    let row = conn.query_row("PRAGMA user_version").ok()?;
+    let value = row.get(0).and_then(SqliteValue::as_integer)?;
+    u32::try_from(value).ok()
+}
+
 fn database_header_user_version(path: &Path) -> Option<u32> {
     if path == Path::new(":memory:") || !path.is_file() {
         return None;
@@ -19453,19 +19479,30 @@ mod tests {
     }
 
     #[test]
-    fn test_database_header_user_version_reads_file_header_value() {
+    fn test_connection_user_version_sees_wal_resident_value() {
+        // user_version set through one connection must be visible to a fresh
+        // connection via PRAGMA even when it only lives in the WAL (drop
+        // without an explicit close leaves the value uncheckpointed). The
+        // raw header peek is allowed to lag; trusting it for schema
+        // decisions re-applied schema against live databases under
+        // concurrent sessions.
         let temp = TempDir::new().unwrap();
         let db_path = temp.path().join("header_user_version.db");
 
         let conn = Connection::open(db_path.to_string_lossy().into_owned()).unwrap();
         conn.execute(&format!("PRAGMA user_version = {CURRENT_SCHEMA_VERSION}"))
             .unwrap();
-        conn.close().unwrap();
+        drop(conn);
 
+        let reopened = Connection::open(db_path.to_string_lossy().into_owned()).unwrap();
         assert_eq!(
-            database_header_user_version(&db_path),
+            connection_user_version(&reopened),
             Some(u32::try_from(CURRENT_SCHEMA_VERSION).unwrap())
         );
+
+        // The header peek stays a cheap pre-filter: it must identify a valid
+        // SQLite file (Some), but its value may lag the WAL.
+        assert!(database_header_user_version(&db_path).is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`open_with_timeout` decides whether the schema is current by reading `user_version` from the raw SQLite file header (byte offset 60). Header bytes do not see WAL-resident values, so when another process holds an uncheckpointed WAL, a fully current database reads as stale and schema gets re-applied against live data.

Observed in the field with two agent sessions working one repo: `br show`/`br close` returned issue-not-found for rows `br list` displayed, and `br update` echoed titles from unrelated rows, until `br doctor --repair` rebuilt the DB from JSONL. `br doctor` at the time also flagged the WAL sidecar state.

## Fix

- `open_with_timeout` queries `PRAGMA user_version` through the already-open connection (reads through the WAL), falling back to the header peek only when the PRAGMA itself errors — e.g. a corrupted file — so `doctor` can still open and diagnose rather than re-applying schema over corruption.
- `open_current_read_only` keeps the header peek as a cheap is-this-a-SQLite-file pre-filter and confirms the version through its read-only connection. Previously a WAL-resident version could disqualify a current database from read-only opens entirely.

## Testing

- Rewrote the header test to assert WAL-visibility semantics (set `user_version`, drop without close, fresh connection must see it via the helper; the header peek may lag).
- Stress: hundreds of point lookups under concurrent update + `sync` churn across two processes, zero misses; previously intermittent not-found/wrong-row.
- Full suite run against this change shows no regressions relative to main.