### PR TITLE
Add Claude Code and Codex plugin manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "beads-rust",
+  "owner": {
+    "name": "Dicklesworthstone"
+  },
+  "description": "beads_rust / br issue tracker skills for Claude Code and Codex.",
+  "plugins": [
+    {
+      "name": "br",
+      "source": "./",
+      "description": "Official beads_rust / br issue tracker skills.",
+      "category": "productivity",
+      "keywords": [
+        "br",
+        "beads",
+        "beads-rust",
+        "issue-tracker",
+        "tasks"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "description": "beads_rust / br issue tracker skills for Claude Code and Codex.",
   "plugins": [
     {
-      "name": "br",
+      "name": "beads-rust",
       "source": "./",
       "description": "Official beads_rust / br issue tracker skills.",
       "category": "productivity",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "br",
+  "version": "1.0.0",
+  "description": "Official beads_rust / br issue tracker skills for Claude Code and Codex.",
+  "author": {
+    "name": "Dicklesworthstone"
+  },
+  "homepage": "https://github.com/Dicklesworthstone/beads_rust",
+  "repository": "https://github.com/Dicklesworthstone/beads_rust",
+  "license": "MIT",
+  "skills": [
+    "./.claude/skills"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "br",
+  "name": "beads-rust",
   "version": "1.0.0",
   "description": "Official beads_rust / br issue tracker skills for Claude Code and Codex.",
   "author": {

--- a/README.md
+++ b/README.md
@@ -349,14 +349,14 @@ For Codex:
 
 ```bash
 codex plugin marketplace add Dicklesworthstone/beads_rust
-codex plugin add br@beads-rust
+codex plugin add beads-rust@beads-rust
 ```
 
 For Claude Code:
 
 ```bash
 claude plugin marketplace add Dicklesworthstone/beads_rust
-claude plugin install br@beads-rust
+claude plugin install beads-rust@beads-rust
 ```
 
 ### Enable MCP Server Support

--- a/README.md
+++ b/README.md
@@ -339,6 +339,26 @@ cargo build --release --no-default-features
 cargo install --git https://github.com/Dicklesworthstone/beads_rust.git beads_rust --locked --no-default-features
 ```
 
+### Claude Code and Codex Skills
+
+The repository also publishes the `br` agent skills as a GitHub-backed plugin
+for Claude Code and Codex. This installs the agent instructions only; install
+the `br` CLI separately with one of the commands above.
+
+For Codex:
+
+```bash
+codex plugin marketplace add Dicklesworthstone/beads_rust
+codex plugin add br@beads-rust
+```
+
+For Claude Code:
+
+```bash
+claude plugin marketplace add Dicklesworthstone/beads_rust
+claude plugin install br@beads-rust
+```
+
 ### Enable MCP Server Support
 
 `br serve` is optional and is not built by the default feature set. Build with


### PR DESCRIPTION
Adds .claude-plugin marketplace and plugin manifests so beads_rust can be installed as a GitHub-backed Claude Code and
  Codex plugin.

  The plugin exposes all official skills under .claude/skills and documents install commands for both CLIs. It installs
  agent instructions only; users still install the br binary separately.
