### PR TITLE
fix(blocked): preserve line breaks in rich output

### DIFF
--- a/src/cli/commands/blocked.rs
+++ b/src/cli/commands/blocked.rs
@@ -449,6 +449,17 @@ fn render_blocked_rich(
     storage: &crate::storage::SqliteStorage,
     max_width: usize,
 ) {
+    let console = rich_rust::Console::default();
+    render_blocked_rich_to_console(blocked_issues, verbose, storage, max_width, &console);
+}
+
+fn render_blocked_rich_to_console(
+    blocked_issues: &[BlockedIssue],
+    verbose: bool,
+    storage: &crate::storage::SqliteStorage,
+    max_width: usize,
+    console: &rich_rust::Console,
+) {
     use crate::format::{format_status_label, sanitize_terminal_inline, truncate_title};
     use rich_rust::Text;
     use rich_rust::prelude::*;
@@ -457,8 +468,6 @@ fn render_blocked_rich(
         Color::parse(name).unwrap_or_default()
     }
 
-    let console = Console::default();
-
     if blocked_issues.is_empty() {
         let mut text = Text::new("");
         text.append_styled("\u{2728} ", Style::new().color(color("green")));
@@ -466,7 +475,7 @@ fn render_blocked_rich(
             "No blocked issues",
             Style::new().bold().color(color("green")),
         );
-        console.print_renderable(&text);
+        console.print_text(&text);
         return;
     }
 
@@ -475,7 +484,7 @@ fn render_blocked_rich(
     header.append_styled("\u{1f6ab} ", Style::new().color(color("red")));
     header.append_styled("Blocked issues", Style::new().bold().color(color("red")));
     header.append_styled(&format!(" ({})", blocked_issues.len()), Style::new().dim());
-    console.print_renderable(&header);
+    console.print_text(&header);
     console.print("");
 
     for bi in blocked_issues {
@@ -509,12 +518,12 @@ fn render_blocked_rich(
         line.append(": ");
         line.append(&title);
         line.append_styled(&format!(" [{} blockers]", blocker_count), count_style);
-        console.print_renderable(&line);
+        console.print_text(&line);
 
         if verbose {
             let mut blocked_label = Text::new("");
             blocked_label.append_styled("  Blocked by:", Style::new().dim());
-            console.print_renderable(&blocked_label);
+            console.print_text(&blocked_label);
 
             for blocker_ref in &bi.blocked_by {
                 let blocker_id = blocker_id_from_ref(blocker_ref);
@@ -542,7 +551,7 @@ fn render_blocked_rich(
                 } else {
                     blocker_line.append_styled(" (not found)", Style::new().dim());
                 }
-                console.print_renderable(&blocker_line);
+                console.print_text(&blocker_line);
             }
         } else {
             let mut detail = Text::new("");
@@ -551,7 +560,7 @@ fn render_blocked_rich(
                 &format!("[{}]", blocked_id_list_text(&bi.blocked_by)),
                 Style::new().color(color("yellow")),
             );
-            console.print_renderable(&detail);
+            console.print_text(&detail);
         }
     }
 }
@@ -622,6 +631,48 @@ mod tests {
             blocked_by_count: blocker_count,
             blocked_by: (0..blocker_count).map(|i| format!("blocker-{i}")).collect(),
         }
+    }
+
+    #[test]
+    fn rich_blocked_output_separates_records_with_newlines() {
+        let storage = SqliteStorage::open_memory().expect("open test storage");
+        let issues = vec![
+            BlockedIssue {
+                issue: make_issue("br-spec", "Publish the workflow spec", 1, IssueType::Task),
+                blocked_by_count: 2,
+                blocked_by: vec!["br-research".to_string(), "br-prototype".to_string()],
+            },
+            BlockedIssue {
+                issue: make_issue(
+                    "br-prototype",
+                    "Validate the CLI workflow",
+                    2,
+                    IssueType::Task,
+                ),
+                blocked_by_count: 1,
+                blocked_by: vec!["br-grilling".to_string()],
+            },
+        ];
+        let console = rich_rust::Console::builder().force_terminal(false).build();
+
+        console.begin_capture();
+        render_blocked_rich_to_console(&issues, false, &storage, 0, &console);
+        let rendered: String = console
+            .end_capture()
+            .iter()
+            .map(|segment| segment.text.as_ref())
+            .collect();
+
+        assert_eq!(
+            rendered,
+            concat!(
+                "🚫 Blocked issues (2)\n\n",
+                "[P1] br-spec: Publish the workflow spec [2 blockers]\n",
+                "  Blocked by: [br-research, br-prototype]\n",
+                "[P2] br-prototype: Validate the CLI workflow [1 blockers]\n",
+                "  Blocked by: [br-grilling]\n",
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Preserve record separation when rendering `br blocked` in rich output mode.

## Cause

Prepared `Text` values were passed through `Console::print_renderable`.
With the current `rich_rust` implementation, that path renders `Text` with an
empty line ending, causing headers, issue rows, and detail rows to collapse
together.

## Changes

- render prepared rich `Text` values through `Console::print_text`
- extract a console-injectable rendering helper
- apply the corrected path consistently to empty, compact, and detailed output
- add a captured-output regression test proving consecutive records remain on
  separate lines

Plain and structured output modes are unchanged.

## Validation

- [x] `git diff --check`
- [ ] `cargo fmt --check`
- [ ] `cargo check --all-targets`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] focused rich blocked-output regression test