### PR TITLE
fix(workspace): rebuild a missing database from canonical JSONL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn main() {
         && !matches!(cli.command, Commands::Doctor(_))
         && let Some(paths) = ctx.paths.as_ref()
     {
-        match commands::doctor::inspect_pending_sync_merge_at_path(&paths.db_path) {
+        match inspect_pending_sync_merge_for_startup(&paths.db_path) {
             Ok(Some(state)) => {
                 emit_pending_sync_merge_warning(&state, json_error_mode);
                 pending_merge_warning_emitted = true;
@@ -251,7 +251,7 @@ fn main() {
                 color_error_mode,
             )
         });
-        match inspect_pending_sync_merge_for_no_db_write(&paths.db_path, authority) {
+        match inspect_pending_sync_merge_for_startup_under_authority(&paths.db_path, authority) {
             Ok(Some(state)) => handle_error(
                 &pending_sync_merge_no_db_refusal_error(&state),
                 json_error_mode,
@@ -292,10 +292,7 @@ fn main() {
                 color_error_mode,
             )
         });
-        match commands::doctor::inspect_pending_sync_merge_under_authority(
-            &paths.db_path,
-            authority,
-        ) {
+        match inspect_pending_sync_merge_for_startup_under_authority(&paths.db_path, authority) {
             Ok(Some(state))
                 if pending_merge_disposition == PendingMergeStartupDisposition::Refuse =>
             {
@@ -1232,10 +1229,27 @@ fn pending_sync_merge_no_db_refusal_error(
     }
 }
 
-fn inspect_pending_sync_merge_for_no_db_write(
+fn inspect_pending_sync_merge_for_startup(
+    db_path: &Path,
+) -> Result<Option<commands::doctor::PendingSyncMergeState>> {
+    // A missing database is the normal pre-import state for a JSONL-only
+    // checkout. It cannot contain a pending receipt, so startup must remain
+    // free to create and import it. Doctor still reports the missing database
+    // as a finding through its stricter public inspector.
+    match fs::symlink_metadata(db_path) {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        _ => commands::doctor::inspect_pending_sync_merge_at_path(db_path),
+    }
+}
+
+fn inspect_pending_sync_merge_for_startup_under_authority(
     db_path: &Path,
     authority: &Arc<beads_rust::sync::DatabaseFamilyWriteLock>,
 ) -> Result<Option<commands::doctor::PendingSyncMergeState>> {
+    // Binding an exactly absent database under the held family authority makes
+    // that absence definitive for the startup gate. The subsequent writable
+    // open may then initialize it without leaving an unchecked replacement
+    // window.
     if authority.bind_database_inode_for_mutation()? {
         authority.verify_database_authority()?;
         return Ok(None);
@@ -2747,7 +2761,7 @@ mod tests {
         );
 
         assert!(
-            inspect_pending_sync_merge_for_no_db_write(&db_path, &authority)
+            inspect_pending_sync_merge_for_startup_under_authority(&db_path, &authority)
                 .unwrap()
                 .is_none(),
             "an exact missing DB cannot contain a pending receipt"
@@ -2764,6 +2778,23 @@ mod tests {
             "missing-DB classification must permit ordinary no-DB JSONL work"
         );
         assert!(!db_path.exists());
+    }
+
+    #[test]
+    fn startup_advisory_allows_exact_missing_database() {
+        let temp = TempDir::new().unwrap();
+        let db_path = temp.path().join("beads.db");
+
+        assert!(
+            inspect_pending_sync_merge_for_startup(&db_path)
+                .unwrap()
+                .is_none(),
+            "a JSONL-only checkout must be allowed to initialize its database"
+        );
+        assert!(
+            !db_path.exists(),
+            "advisory inspection must remain read-only"
+        );
     }
 
     #[test]
@@ -2792,9 +2823,10 @@ mod tests {
                 .unwrap(),
             );
 
-            let state = inspect_pending_sync_merge_for_no_db_write(&db_path, &authority)
-                .unwrap()
-                .expect("pending state must refuse no-DB writer");
+            let state =
+                inspect_pending_sync_merge_for_startup_under_authority(&db_path, &authority)
+                    .unwrap()
+                    .expect("pending state must refuse no-DB writer");
             let err = pending_sync_merge_no_db_refusal_error(&state);
 
             assert_eq!(state.condition_name(), expected_condition);

--- a/tests/e2e_workspace_commands.rs
+++ b/tests/e2e_workspace_commands.rs
@@ -7,7 +7,7 @@ mod common;
 
 use common::cli::{BrWorkspace, extract_json_payload, parse_list_issues, run_br, run_br_with_env};
 use fsqlite::Connection;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::fs;
 
 // ============================================================================
@@ -35,6 +35,67 @@ fn e2e_init_new_workspace() {
     // Verify database file exists
     let db_path = beads_dir.join("beads.db");
     assert!(db_path.exists(), "beads.db should exist");
+}
+
+#[test]
+fn e2e_list_rebuilds_missing_database_from_jsonl() {
+    let _log = common::test_log("e2e_list_rebuilds_missing_database_from_jsonl");
+    let workspace = BrWorkspace::new();
+    let beads_dir = workspace.root.join(".beads");
+    fs::create_dir_all(&beads_dir).expect("create .beads");
+    fs::write(
+        beads_dir.join("config.yaml"),
+        "issue_prefix: rebuilt\nissue-prefix: rebuilt\nsync: {}\n",
+    )
+    .expect("write config");
+    fs::write(
+        beads_dir.join("metadata.json"),
+        "{\n  \"database\": \"beads.db\",\n  \"jsonl_export\": \"issues.jsonl\"\n}\n",
+    )
+    .expect("write metadata");
+    let issue = json!({
+        "id": "rebuilt-abc12",
+        "title": "Imported from JSONL-only checkout",
+        "status": "open",
+        "priority": 1,
+        "issue_type": "task",
+        "created_at": "2026-08-06T00:00:00Z",
+        "created_by": "tester",
+        "updated_at": "2026-08-06T00:00:00Z",
+        "labels": [],
+        "ephemeral": false,
+        "pinned": false,
+        "is_template": false,
+        "dependencies": [],
+        "comments": []
+    });
+    fs::write(beads_dir.join("issues.jsonl"), format!("{issue}\n")).expect("write JSONL");
+
+    let listed = run_br(
+        &workspace,
+        ["list", "--json"],
+        "list_rebuild_missing_database",
+    );
+    assert!(
+        listed.status.success(),
+        "list should rebuild a missing database: stdout='{}' stderr='{}'",
+        listed.stdout,
+        listed.stderr
+    );
+    assert!(
+        !listed.stderr.contains("sync-merge state is unknown"),
+        "missing database must not be misclassified as an unknown pending merge: {}",
+        listed.stderr
+    );
+    assert!(
+        beads_dir.join("beads.db").is_file(),
+        "list auto-import should create the database"
+    );
+    let issues = parse_list_issues(&listed.stdout);
+    assert!(
+        issues.iter().any(|row| row["id"] == "rebuilt-abc12"),
+        "list should include the JSONL issue: {issues:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Hi, I know you’ve said that you don’t generally accept outside contributions and I am not sure about the benefit of this PR in your codebase. So feel free to ignore it.

## Summary

Allow startup to rebuild an exactly missing SQLite database from canonical
JSONL without weakening doctor diagnostics or pending-merge safety.

## Problem

Startup reused the doctor's intentionally strict pending-merge inspector. When
the database was absent, that inspector treated the state as unknown and
prevented normal JSONL bootstrap behavior.

A JSONL-only checkout is a valid initialization and recovery state, so exact
database absence should not be handled like a malformed or ambiguous workspace.

## Changes

- add a startup-specific advisory that accepts exact database absence
- recheck absence while holding database-family mutation authority
- retain strict inspection for existing, malformed, symlinked, and legacy states
- keep the public doctor inspector strict
- add unit coverage proving advisory inspection does not create the database
- add an end-to-end test proving `br list --json` reconstructs the database and
  returns the JSONL issue

## Safety

Writable initialization still occurs under the existing authority and locking
contract. The change does not relax handling of an existing or invalid database.

## Validation

- [x] `git diff --check`
- [ ] `cargo fmt --check`
- [ ] `cargo check --all-targets`
- [ ] `cargo clippy --all-targets -- -D warnings`
- [ ] startup missing-database unit test
- [ ] JSONL-only workspace end-to-end test